### PR TITLE
Add SNS classes from Person API

### DIFF
--- a/Hackney.Core/Hackney.Core.Sns/ContactDetailsConstants.cs
+++ b/Hackney.Core/Hackney.Core.Sns/ContactDetailsConstants.cs
@@ -1,8 +1,0 @@
-﻿namespace Hackney.Shared.Sns
-{
-    public static class ContactDetailsConstants
-    {
-        public const string CREATED = "ContactDetailAddedEvent";
-        public const string DELETED = "ContactDetailDeletedEvent";
-    }
-}

--- a/Hackney.Core/Hackney.Core.Sns/EntityEventSns.cs
+++ b/Hackney.Core/Hackney.Core.Sns/EntityEventSns.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Hackney.Core.Sns
+{
+    public class EntityEventSns
+    {
+        public Guid Id { get; set; }
+
+        public string EventType { get; set; }
+
+        public string SourceDomain { get; set; }
+
+        public string SourceSystem { get; set; }
+
+        public string Version { get; set; }
+
+        public Guid CorrelationId { get; set; }
+
+        public DateTime DateTime { get; set; }
+
+        public User User { get; set; }
+
+        public Guid EntityId { get; set; }
+
+        public EventData EventData { get; set; } = new EventData();
+    }
+
+    public class EventData
+    {
+        public object OldData { get; set; }
+
+        public object NewData { get; set; }
+    }
+}

--- a/Hackney.Core/Hackney.Core.Sns/EventTypes.cs
+++ b/Hackney.Core/Hackney.Core.Sns/EventTypes.cs
@@ -1,0 +1,17 @@
+﻿namespace Hackney.Shared.Sns
+{
+    public static class EventTypes
+    {
+        public const string PersonCreatedEvent = "PersonCreatedEvent";
+        public const string PersonUpdatedEvent = "PersonUpdatedEvent";
+
+        public const string PersonAddedToTenureEvent = "PersonAddedToTenureEvent";
+        public const string PersonRemovedFromTenureEvent = "PersonRemovedFromTenureEvent";
+
+        public const string ContactDetailAddedEvent = "ContactDetailAddedEvent";
+        public const string ContactDetailDeletedEvent = "ContactDetailDeletedEvent";
+
+        public const string TenureCreatedEvent = "TenureCreatedEvent";
+        public const string TenureUpdatedEvent = "TenureUpdatedEvent";
+    }
+}

--- a/Hackney.Core/Hackney.Core.Sns/User.cs
+++ b/Hackney.Core/Hackney.Core.Sns/User.cs
@@ -1,0 +1,9 @@
+namespace Hackney.Core.Sns
+{
+    public class User
+    {
+        public string Name { get; set; }
+
+        public string Email { get; set; }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ For full details on how to use the package(s) within this repository please read
 *Note: The Hackney.Core project has been split into individual packages and is now deprecated.*
 *In order to use our packages, import each Hackney.Core dependency required individually.*
 
+## Adding a new package
+Please refer to [our documentation](https://docs.google.com/document/d/1aJzhNxmSq_D4porwSIa528xYwTghblJmky4decvQBlA/edit?usp=sharing) on creating NuGet packages. For this repository, create your project folder in the `Hackney.Core` folder and test folder in `Hackney.Core.Tests`. Use the [workflow template](.github/workflows-template/publish.yml) to create your own workflow file in the `.github/workflows` folder.
+
 ## Features
 
 The following features are implemented within this package.
@@ -38,6 +41,7 @@ The following features are implemented within this package.
   * [Lambda logging](#Lambda-logging)
 * [Sns](#Sns)
   * [Sns Gateway](#Sns-Gateway)
+  * [Shared Classes](#Shared-Classes)
 * [Validation](#Validation)
   * [XssValidator](#XssValidator)
 
@@ -539,6 +543,12 @@ namespace SomeApi
 #### Sns Gateway
 The `SnsGateway` implementation of the `ISnsGateway` interface allows the easy publishing of an event message to an Sns topic.
 The `ISnsGateway` interface is made available by using the `AddSnsGateway()` extension method during your application start-up.
+
+#### Shared Classes
+- EntityEventSns - Model of the event message received by a function
+- EventData - Contains the data changed in an event
+- User - Contains information about a user triggering an event
+- EventTypes - Names all events we are currently using
 
 ### Validation
 


### PR DESCRIPTION
## Link to JIRA ticket

Done as part of this ticket: https://hackney.atlassian.net/browse/TL-53

## Describe this PR

Some classes from the API are shared between multiple APIs so should go in the `Hackney.Core` packages rather than individual shared packages.

### *What changes have we introduced*

Added `EntityEventSns`, `EventData`, `User` and `EventTypes` classes

#### _Checklist_

- [x] Added comments to the README or updated relevant documentation where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Remove duplicated files from listeners and reference this package instead.
