### PR TITLE
Remove LogCallAspectFixtureCollection

### DIFF
--- a/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj
+++ b/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj
@@ -26,7 +26,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
   </ItemGroup>
 
 

--- a/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/LogCallAspectFixture.cs
+++ b/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/LogCallAspectFixture.cs
@@ -3,18 +3,16 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Logging;
 using Moq;
 using System;
-using Xunit;
 
 namespace Hackney.Core.Testing.Shared
 {
     /// <summary>
-    /// This fixture & collection should be used for on all test classes that are testing classes that use
-    /// the LogCall attribute.
+    /// This fixture should be used in an xunit collection and then that collection used 
+    /// on all test classes that are testing classes that use the LogCall attribute.
     /// This is required because the AspectInjector framework operates at compile-time.
     /// This means that simply constructing an instance of a class that uses the attribute requires all of
     /// supporting objects used by the LogCallAspect to also be set up.
     /// </summary>
-
     public class LogCallAspectFixture
     {
         public Mock<ILogger<LogCallAspect>> MockLogger { get; private set; }
@@ -37,10 +35,5 @@ namespace Hackney.Core.Testing.Shared
             return mockLogger;
         }
     }
-
-    [CollectionDefinition("LogCall collection")]
-    public class LogCallAspectFixtureCollection : ICollectionFixture<LogCallAspectFixture>
-    { }
-
 }
 

--- a/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/README.md
+++ b/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/README.md
@@ -90,8 +90,8 @@ namespace SomeNamespace.Tests.E2E.Fixture
 The `BaseSteps` class is a base class for implementing a BDDfy "steps" class.
 
 ## LogCallAspectFixture
-This provides a pre-configured [xunit collection](https://xunit.net/docs/shared-context#collection-fixture) 
-for use with testing any class that makes use of the [LogCall functionality](/README.md#Log-call-aspect) 
+This fixture should be used in an [xunit collection](https://xunit.net/docs/shared-context#collection-fixture) 
+which should then be used with testing any class that makes use of the [LogCall functionality](/README.md#Log-call-aspect) 
 within the Hackney.Core.Logging package.
 If a class under test has this attribute then unit tests will fail unless the appropriate pre-test configuration is done, 
 and this is provided by this pre-built collection.
@@ -100,14 +100,21 @@ operates at compile-time.
 This means that simply constructing an instance of a class that uses the attribute requires all of the 
 supporting objects used by the LogCallAspect to also be set up.
 
+The reason a common collection cannot be added here is because xunit will not recognise colelction classes 
+definied in assemblies other than the one containing the tests.
+
 
 #### Usage
 ```csharp
 using Hackney.Core.Testing.Shared;
 using Xunit;
 
-namespace SomeDomain.Tests.UseCase
-{
+namespace SomeDomain.Tests
+{    
+    [CollectionDefinition("LogCall collection")]
+    public class LogCallAspectFixtureCollection : ICollectionFixture<LogCallAspectFixture>
+    { }
+
     [Collection("LogCall collection")]
     public class SomeUseCaseTests
     {

--- a/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/xunit.runner.json
+++ b/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/xunit.runner.json
@@ -1,3 +1,0 @@
-{
-  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
-}

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The following features are implemented within this package.
   * [Lambda logging](#Lambda-logging)
 * [Sns](/Hackney.Core/Hackney.Core.Sns/README.md)
 * [Validation](/Hackney.Core/Hackney.Core.Validation/README.md)
-* [Validation.AspNet](/Hackney.Core/Hackney.Core.Validation.AspNet/README.md)
+* [Validation.AspNet](/Hackney.Core/Hackney.Core.Validation.AspNet/ReadMe.md)
 * Testing
   * [Hackney.Core.Testing.Shared](/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/README.md)
 


### PR DESCRIPTION
Remove LogCallAspectFixtureCollection from shared testing package as it doesn't work when not directly in a test assembly.
