### PR TITLE
Add API key config to API Gateway and Base API Fixture

### DIFF
--- a/Hackney.Core.Tests/Hackney.Core.Tests.Authorization/ApplicationBuilderExtensionTests.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.Authorization/ApplicationBuilderExtensionTests.cs
@@ -11,9 +11,9 @@ namespace Hackney.Core.Tests.Authorization
         public void UseGoogleGroupAuthorizationTestNullAppThrows()
         {
             IApplicationBuilder app = null;
-            
+
             Action act = () => Hackney.Core.Authorization.ApplicationBuilderExtension.UseGoogleGroupAuthorization(app);
-            
+
             act.Should().Throw<ArgumentNullException>().WithMessage("Value cannot be null. (Parameter 'IApplicationBuilder')");
         }
     }

--- a/Hackney.Core.Tests/Hackney.Core.Tests.Authorization/BaseErrorResponseTests.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.Authorization/BaseErrorResponseTests.cs
@@ -10,7 +10,7 @@ namespace Hackney.Core.Tests.Authorization
         [Theory]
         [InlineData("Message", (int)HttpStatusCode.Forbidden, "Details", "Details")]
         [InlineData("Message", (int)HttpStatusCode.Forbidden, null, "")]
-        public void BaseErrorResponseConstructorWithDifferentDetails(string expectedMessage, int expectedStatusCode, 
+        public void BaseErrorResponseConstructorWithDifferentDetails(string expectedMessage, int expectedStatusCode,
             string actualDetails, string expectedDetails)
         {
             var sut = new BaseErrorResponse(expectedStatusCode, expectedMessage, actualDetails);

--- a/Hackney.Core.Tests/Hackney.Core.Tests.Authorization/GoogleGroupsAuthorizationMiddlewareTests.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.Authorization/GoogleGroupsAuthorizationMiddlewareTests.cs
@@ -19,7 +19,7 @@ namespace Hackney.Core.Tests.Authorization
         {
             DefaultHttpContext httpContext = new DefaultHttpContext();
             httpContext.Response.Body = new MemoryStream();
-            
+
             var mockTokenFactory = new Mock<ITokenFactory>();
             mockTokenFactory.Setup(x => x.Create(It.IsAny<IHeaderDictionary>(), It.IsAny<string>()))
                 .Throws(new ArgumentNullException("MyException"));
@@ -29,12 +29,12 @@ namespace Hackney.Core.Tests.Authorization
                 .Returns(Task.FromResult(0));
 
             var sut = new GoogleGroupsAuthorizationMiddleware(mockRequestDelegate.Object);
-            Func<Task> act =  () => sut.Invoke(httpContext, mockTokenFactory.Object);
+            Func<Task> act = () => sut.Invoke(httpContext, mockTokenFactory.Object);
 
             await act.Should().ThrowAsync<ArgumentNullException>().WithMessage("Value cannot be null. (Parameter 'MyException')").ConfigureAwait(false);
             mockRequestDelegate.Verify(x => x.Invoke(It.IsAny<HttpContext>()), Times.Never);
         }
-        
+
         [Fact]
         public async Task GoogleGroupsAuthorizationMiddlewareInvoke_TestNullToken_HasUnauthorizedResponse()
         {
@@ -44,15 +44,15 @@ namespace Hackney.Core.Tests.Authorization
 
             DefaultHttpContext httpContext = new DefaultHttpContext();
             httpContext.Response.Body = new MemoryStream();
-            
+
             var mockTokenFactory = new Mock<ITokenFactory>();
             mockTokenFactory.Setup(x => x.Create(It.IsAny<IHeaderDictionary>(), It.IsAny<string>()))
                 .Returns(expectedToken);
-            
+
             var mockRequestDelegate = new Mock<RequestDelegate>();
             mockRequestDelegate.Setup(x => x.Invoke(It.IsAny<HttpContext>()))
                 .Returns(Task.FromResult(0));
-            
+
             var sut = new GoogleGroupsAuthorizationMiddleware(mockRequestDelegate.Object);
             await sut.Invoke(httpContext, mockTokenFactory.Object).ConfigureAwait(false);
 
@@ -73,7 +73,7 @@ namespace Hackney.Core.Tests.Authorization
         [Fact]
         public async Task GoogleGroupsAuthorizationMiddlewareInvoke_TestTokenGroupsAreNull_HasForbiddenResponse()
         {
-            Token expectedToken = new Token 
+            Token expectedToken = new Token
             {
                 Groups = null
             };
@@ -114,7 +114,7 @@ namespace Hackney.Core.Tests.Authorization
             Environment.SetEnvironmentVariable("REQUIRED_GOOGL_GROUPS", null);
             Token expectedToken = new Token
             {
-                Groups = new string[] { "HackneyAll"}
+                Groups = new string[] { "HackneyAll" }
             };
             var expectedResponseText = "Cannot resolve REQUIRED_GOOGL_GROUPS environment variable!";
             var expectedStatusCode = (int)HttpStatusCode.InternalServerError;
@@ -151,7 +151,7 @@ namespace Hackney.Core.Tests.Authorization
         public async Task GoogleGroupsAuthorizationMiddlewareInvoke_TestNoRequiredGoogleGroupsInToken_HasForbiddenResponse()
         {
             Environment.SetEnvironmentVariable("REQUIRED_GOOGL_GROUPS", "GoodGroup; HackneyAll;");
-            Token expectedToken = new Token 
+            Token expectedToken = new Token
             {
                 Groups = new string[] { "HackneyAll", "BadGroup" }
             };
@@ -185,12 +185,12 @@ namespace Hackney.Core.Tests.Authorization
             }
             mockRequestDelegate.Verify(x => x.Invoke(It.IsAny<HttpContext>()), Times.Never);
         }
-        
+
         [Fact]
         public async Task GoogleGroupsAuthorizationMiddlewareInvoke_TestValidToken_CallsNextDelegate()
         {
             Environment.SetEnvironmentVariable("REQUIRED_GOOGL_GROUPS", "GoodGroup; HackneyAll;");
-            Token expectedToken = new Token 
+            Token expectedToken = new Token
             {
                 Groups = new string[] { "HackneyAll", "GoodGroup", "SomeMoreGroup" }
             };
@@ -205,7 +205,7 @@ namespace Hackney.Core.Tests.Authorization
             var mockRequestDelegate = new Mock<RequestDelegate>();
             mockRequestDelegate.Setup(x => x.Invoke(It.IsAny<HttpContext>()))
                 .Returns(Task.FromResult(0));
-            
+
             var sut = new GoogleGroupsAuthorizationMiddleware(mockRequestDelegate.Object);
             await sut.Invoke(httpContext, mockTokenFactory.Object).ConfigureAwait(false);
 

--- a/Hackney.Core/Hackney.Core.Http/ApiGateway.cs
+++ b/Hackney.Core/Hackney.Core.Http/ApiGateway.cs
@@ -55,7 +55,8 @@ namespace Hackney.Core.Http
         /// <param name="apiName">The Api name</param>
         /// <param name="configKeyApiUrl">The configuration key containing the base uri route for the Api</param>
         /// <param name="configKeyApiToken">The configuration key containing the token to be used with the Api</param>
-        /// <param name="headers">Any heasders to be used when calling the Api (optional)</param>
+        /// <param name="headers">Any headers to be used when calling the Api (optional)</param>
+        /// <param name="useApiKey">Set to 'true' if this API needs an 'x-api-key' header rather than 'Authorization' (optional)</param>
         public void Initialise(string apiName, string configKeyApiUrl, string configKeyApiToken, Dictionary<string, string> headers = null, bool useApiKey = false)
         {
             if (string.IsNullOrEmpty(apiName)) throw new ArgumentNullException(nameof(apiName));

--- a/Hackney.Core/Hackney.Core.Http/ApiGateway.cs
+++ b/Hackney.Core/Hackney.Core.Http/ApiGateway.cs
@@ -40,6 +40,7 @@ namespace Hackney.Core.Http
         /// </summary>
         public Dictionary<string, string> RequestHeaders { get; private set; }
 
+        private bool _useApiKey;
         private bool _initialised = false;
 
         public ApiGateway(IHttpClientFactory httpClientFactory, IConfiguration configuration)
@@ -55,7 +56,7 @@ namespace Hackney.Core.Http
         /// <param name="configKeyApiUrl">The configuration key containing the base uri route for the Api</param>
         /// <param name="configKeyApiToken">The configuration key containing the token to be used with the Api</param>
         /// <param name="headers">Any heasders to be used when calling the Api (optional)</param>
-        public void Initialise(string apiName, string configKeyApiUrl, string configKeyApiToken, Dictionary<string, string> headers = null)
+        public void Initialise(string apiName, string configKeyApiUrl, string configKeyApiToken, Dictionary<string, string> headers = null, bool useApiKey = false)
         {
             if (string.IsNullOrEmpty(apiName)) throw new ArgumentNullException(nameof(apiName));
             ApiName = apiName;
@@ -72,6 +73,7 @@ namespace Hackney.Core.Http
 
             RequestHeaders = headers ?? new Dictionary<string, string>();
 
+            _useApiKey = useApiKey;
             _initialised = true;
         }
 
@@ -93,7 +95,12 @@ namespace Hackney.Core.Http
 
             client.DefaultRequestHeaders.Clear();
             client.DefaultRequestHeaders.Add("x-correlation-id", correlationId.ToString());
-            client.DefaultRequestHeaders.Authorization = AuthenticationHeaderValue.Parse(ApiToken);
+
+            if (_useApiKey)
+                client.DefaultRequestHeaders.Add("x-api-key", AuthenticationHeaderValue.Parse(ApiToken).ToString());
+            else
+                client.DefaultRequestHeaders.Authorization = AuthenticationHeaderValue.Parse(ApiToken);
+
             foreach (var pair in RequestHeaders)
                 client.DefaultRequestHeaders.Add(pair.Key, pair.Value);
 

--- a/Hackney.Core/Hackney.Core.Http/ApiGateway.cs
+++ b/Hackney.Core/Hackney.Core.Http/ApiGateway.cs
@@ -1,4 +1,4 @@
-﻿using Hackney.Core.Http.Exceptions;
+using Hackney.Core.Http.Exceptions;
 using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
@@ -97,7 +97,7 @@ namespace Hackney.Core.Http
             client.DefaultRequestHeaders.Add("x-correlation-id", correlationId.ToString());
 
             if (_useApiKey)
-                client.DefaultRequestHeaders.Add("x-api-key", AuthenticationHeaderValue.Parse(ApiToken).ToString());
+                client.DefaultRequestHeaders.Add("x-api-key", ApiToken);
             else
                 client.DefaultRequestHeaders.Authorization = AuthenticationHeaderValue.Parse(ApiToken);
 

--- a/Hackney.Core/Hackney.Core.Http/IApiGateway.cs
+++ b/Hackney.Core/Hackney.Core.Http/IApiGateway.cs
@@ -36,7 +36,7 @@ namespace Hackney.Core.Http
         /// <param name="configKeyApiUrl">The configuration key containing the base uri route for the Api</param>
         /// <param name="configKeyApiToken">The configuration key containing the token to be used with the Api</param>
         /// <param name="headers">Any heasders to be used when calling the Api (optional)</param>
-        /// <param name="useApiKey">Set to 'true' if this API needs an 'x-api-key' header rather than 'Authorization'</param>
+        /// <param name="useApiKey">Set to 'true' if this API needs an 'x-api-key' header rather than 'Authorization' (optional)</param>
         void Initialise(string apiName, string configKeyApiUrl, string configKeyApiToken, Dictionary<string, string> headers = null, bool useApiKey = false);
 
         /// <summary>

--- a/Hackney.Core/Hackney.Core.Http/IApiGateway.cs
+++ b/Hackney.Core/Hackney.Core.Http/IApiGateway.cs
@@ -36,7 +36,8 @@ namespace Hackney.Core.Http
         /// <param name="configKeyApiUrl">The configuration key containing the base uri route for the Api</param>
         /// <param name="configKeyApiToken">The configuration key containing the token to be used with the Api</param>
         /// <param name="headers">Any heasders to be used when calling the Api (optional)</param>
-        void Initialise(string apiName, string configKeyApiUrl, string configKeyApiToken, Dictionary<string, string> headers = null);
+        /// <param name="useApiKey">Set to 'true' if this API needs an 'x-api-key' header rather than 'Authorization'</param>
+        void Initialise(string apiName, string configKeyApiUrl, string configKeyApiToken, Dictionary<string, string> headers = null, bool useApiKey = false);
 
         /// <summary>
         /// Makes a basic GET call to the Api to retrieve the requestsed entity details from it

--- a/Hackney.Core/Hackney.Core.Http/README.md
+++ b/Hackney.Core/Hackney.Core.Http/README.md
@@ -39,7 +39,7 @@ namespace SomeApi
 
 ### Implementation
 Create a "Gateway" class as normal to encapsulate calling the required external Api. 
-The class should inject an instance of the IApiGateway into and should initialise it with the required name, and configuration keys for the uri and token.
+The class should inject an instance of the IApiGateway into and should initialise it with the required name, and configuration keys for the uri and token. Optionally, you can also add custom headers and toggle the use of API Keys in this initialisation method. 
 
 This class should implement a single `async` Get method, but internally delegate the actual call to the instance of the IApiGateway injected into the class.
 This method will return either the requested entity, null, or throw a `GetFromApiException` exception for any other response from the Api call.
@@ -48,7 +48,7 @@ It is assumed that the Api's base uri and token are set in the application confi
 This would be standard practice so that the appropriate uri/token can be injected into the application container depending on the environment.
 The container tests should ensure that these environment variables are set appropriately.  
 
-**The uri and token are both required - the ApiGateway will throw an excpetion if either is not found at runtime.**
+**The uri and token are both required - the ApiGateway will throw an exception if either is not found at runtime.**
 
 
 ```csharp
@@ -64,15 +64,15 @@ namespace SomeApi.Gateway
     public class SomeEntitytApi : ISomeEntityApi
     {
         private const string ApiName = "SomeEntity";
-        private const string AccountApiUrl = "SomeEntityApiUrl";
-        private const string AccountApiToken = "SomeEntityApiToken";
+        private const string ApiUrl = "SomeEntityApiUrl";
+        private const string ApiToken = "SomeEntityApiToken";
 
         private readonly IApiGateway _apiGateway;
 
         public SomeEntityApi(IApiGateway apiGateway)
         {
             _apiGateway = apiGateway;
-            _apiGateway.Initialise(ApiName, AccountApiUrl, AccountApiToken);
+            _apiGateway.Initialise(ApiName, ApiUrl, ApiToken);
         }
 
         [LogCall]

--- a/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/E2E/BaseApiFixture.cs
+++ b/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/E2E/BaseApiFixture.cs
@@ -123,7 +123,7 @@ namespace Hackney.Core.Testing.Shared.E2E
                     HttpListenerResponse response = context.Response;
 
                     if (!string.IsNullOrEmpty(ApiToken)
-                        && (context.Request.Headers["Authorization"] != ApiToken))
+                        && ((context.Request.Headers["Authorization"] != ApiToken) || (context.Request.Headers["x-api-key"] != ApiToken)))
                     {
                         response.StatusCode = (int)HttpStatusCode.Unauthorized;
                     }

--- a/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/E2E/BaseApiFixture.cs
+++ b/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/E2E/BaseApiFixture.cs
@@ -122,10 +122,11 @@ namespace Hackney.Core.Testing.Shared.E2E
                     Requests.Add(context.Request);
                     HttpListenerResponse response = context.Response;
 
-                    if (!string.IsNullOrEmpty(ApiToken)
-                        && ((context.Request.Headers["Authorization"] != ApiToken) || (context.Request.Headers["x-api-key"] != ApiToken)))
+                    var passedToken = context.Request.Headers["Authorization"] ?? context.Request.Headers["x-api-key"];
+                    if (!string.IsNullOrEmpty(ApiToken) && passedToken != ApiToken)
                     {
                         response.StatusCode = (int)HttpStatusCode.Unauthorized;
+                        throw new UnauthorizedAccessException("Request headers do not contain `Authorization` or `x-api-key` keys");
                     }
                     else
                     {


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

The current API Gateway is only configured for using API Tokens in the `Authorization` header, not API keys in the `x-api-key` header. 
### *What changes have we introduced*

This PR adds config for both API tokens and keys. By default, API tokens are used.
I also added an error for when an unauthorised request is made, as right now it just stalls.

#### _Checklist_

- [x] Added tests to cover all new production code
- [x] Added comments to the README where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
