### PR TITLE
Use string IDs in API Gateway

### DIFF
--- a/Hackney.Core.Tests/Hackney.Core.Tests.Http/Exceptions/GetFromApiExceptionTests.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.Http/Exceptions/GetFromApiExceptionTests.cs
@@ -13,7 +13,7 @@ namespace Hackney.Core.Tests.Http.Exceptions
         public void GetFromApiExceptionConstructorTest()
         {
             var type = "SomeEntityName";
-            var id = Guid.NewGuid();
+            var id = Guid.NewGuid().ToString();
             var route = $"Some/route/{id}";
             var statusCode = HttpStatusCode.OK;
             var msg = "Some API error message";
@@ -32,7 +32,7 @@ namespace Hackney.Core.Tests.Http.Exceptions
         public void GetFromApiExceptionConstructorWithHeadersTest()
         {
             var type = "SomeEntityName";
-            var id = Guid.NewGuid();
+            var id = Guid.NewGuid().ToString();
             var route = $"Some/route/{id}";
             var statusCode = HttpStatusCode.OK;
             var msg = "Some API error message";

--- a/Hackney.Core/Hackney.Core.Http/ApiGateway.cs
+++ b/Hackney.Core/Hackney.Core.Http/ApiGateway.cs
@@ -88,7 +88,7 @@ namespace Hackney.Core.Http
         /// <param name="correlationId">The correlation id to use on the request.</param>
         /// <returns>The requested entity if found. null if not found</returns>
         /// <exception cref="GetFromApiException">If the Http GET request returns anything other than a success status code or not found</exception>
-        public async Task<T> GetByIdAsync<T>(string route, Guid id, Guid correlationId) where T : class
+        public async Task<T> GetByIdAsync<T>(string route, string id, Guid correlationId) where T : class
         {
             if (!_initialised) throw new InvalidOperationException("Initialise() must be called before any other calls are made");
 
@@ -117,6 +117,11 @@ namespace Hackney.Core.Http
 
             throw new GetFromApiException(ApiName, route, client.DefaultRequestHeaders.ToList(),
                                           id, response.StatusCode, responseBody);
+        }
+
+        public async Task<T> GetByIdAsync<T>(string route, Guid id, Guid correlationId) where T : class
+        {
+            return await GetByIdAsync<T>(route, id.ToString(), correlationId).ConfigureAwait(false);
         }
     }
 }

--- a/Hackney.Core/Hackney.Core.Http/Exceptions/GetFromApiException.cs
+++ b/Hackney.Core/Hackney.Core.Http/Exceptions/GetFromApiException.cs
@@ -22,7 +22,7 @@ namespace Hackney.Core.Http.Exceptions
         /// <summary>
         /// The entity Id requested
         /// </summary>
-        public Guid EntityId { get; }
+        public string EntityId { get; }
 
         /// <summary>
         /// The headers used in the GET request
@@ -39,12 +39,12 @@ namespace Hackney.Core.Http.Exceptions
         /// </summary>
         public string ResponseBody { get; }
 
-        public GetFromApiException(string type, string route, Guid id, HttpStatusCode statusCode, string responseBody)
+        public GetFromApiException(string type, string route, string id, HttpStatusCode statusCode, string responseBody)
             : this(type, route, new List<KeyValuePair<string, IEnumerable<string>>>(), id, statusCode, responseBody)
         { }
 
         public GetFromApiException(string type, string route, IEnumerable<KeyValuePair<string, IEnumerable<string>>> headers,
-            Guid id, HttpStatusCode statusCode, string responseBody)
+            string id, HttpStatusCode statusCode, string responseBody)
             : base($"Failed to get {type} details for id {id}. Route: {route}; Status code: {statusCode}; Message: {responseBody}")
         {
             EntityType = type;

--- a/Hackney.Core/Hackney.Core.Http/IApiGateway.cs
+++ b/Hackney.Core/Hackney.Core.Http/IApiGateway.cs
@@ -48,5 +48,15 @@ namespace Hackney.Core.Http
         /// <param name="correlationId">The correlation id to use on the request.</param>
         /// <returns>The requested entity</returns>
         Task<T> GetByIdAsync<T>(string route, Guid id, Guid correlationId) where T : class;
+
+        /// <summary>
+        /// Makes a basic GET call to the Api to retrieve the requestsed entity details from it
+        /// </summary>
+        /// <typeparam name="T">The entity type required</typeparam>
+        /// <param name="route">The full route to the GET endpoint</param>
+        /// <param name="id">The id of the requested object</param>
+        /// <param name="correlationId">The correlation id to use on the request.</param>
+        /// <returns>The requested entity</returns>
+        Task<T> GetByIdAsync<T>(string route, string id, Guid correlationId) where T : class;
     }
 }


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

Some APIs use string IDs instead of guid IDs, which breaks the `GetByIdAsync` function in the API Gateway.

### *What changes have we introduced*

- Updated the GetByIdAsync function to use string IDs.
- Created a new function where a guid ID can be used for API calls, for backwards compatibility.

#### _Checklist_

- [x] Added tests to cover all new production code
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
