### PR TITLE
Add branch names to NuGet package versions

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -8,7 +8,7 @@ branches:
     is-mainline: true
   feature:
     regex: feature[/-]
-    tag: preview
+    tag: "feat-{BranchName}"
     increment: Minor
     source-branches: ['master', 'main', 'release']
 ignore:

--- a/README.md
+++ b/README.md
@@ -1,18 +1,27 @@
-# Hackney.Core NuGet Package
-At Hackney, we have created the NuGet Package to prevent the duplication of common code when implementing our APIs.
-Hence this NuGet package will store the common code that can then be used in the relevant projects. 
+# Hackney.Core NuGet Packages
+At Hackney, we have created NuGet Packagse to prevent the duplication of common code when implementing our APIs.
+Hence this NuGet package will store common code that can then be used in relevant projects. 
 
-#### GitHub Actions Pipeline - Versioning
-The pipeline automatically updates the package version number using [GitVersion](https://gitversion.net/).
+## Contributing
 
-Version numbers use the following format:
+### Automated Versioning
+The pipeline automatically updates the version number for all packages in Hackney.Core.
 
-Any specific version number follows the form Major.Minor.Patch[-Suffix], where the components have the following meanings:
+Any specific version number follows the form `Major.Minor.Patch[-Suffix]`, where the components have the following meanings:
 
 * *Major*: Breaking changes
 * *Minor*: New features, but backward compatible
 * *Patch*: Backwards compatible bug fixes only
 * *Suffix (optional)*: a hyphen followed by a string denoting a pre-release version
+
+### Branching Strategy
+
+In order for the pipeline to be able to run automated tests and create preview versions of packages, you must name your branch correctly.
+
+**Name your branch following the convention of `feature/<some-feature>`.** This will allow the pipeline to work correctly. 
+If all tests pass, a new version of your package will be publised on every commit. You can see published versions of packages [here](https://github.com/orgs/LBHackney-IT/packages?repo_name=lbh-core).
+
+All preview versions of packages will have the suffix **`-feat-<branch-name>-<number>`**
 
 ## Building the package
 After cloning the repo, you may find many errors relating to the `Hackney.Core.Testing.PactBroker` project similar to the one below when attempting to build the solution **_on a Windows machine_**:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Hackney.Core NuGet Packages
-At Hackney, we have created NuGet Packagse to prevent the duplication of common code when implementing our APIs.
+At Hackney, we have created NuGet Packages to prevent the duplication of common code when implementing our APIs.
 Hence this NuGet package will store common code that can then be used in relevant projects. 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ In order for the pipeline to be able to run automated tests and create preview v
 **Name your branch following the convention of `feature/<some-feature>`.** This will allow the pipeline to work correctly. 
 If all tests pass, a new version of your package will be publised on every commit. You can see published versions of packages [here](https://github.com/orgs/LBHackney-IT/packages?repo_name=lbh-core).
 
-All preview versions of packages will have the suffix **`-feat-<branch-name>-<number>`**
+All preview versions of packages will have the suffix **`-feat-<branch-name>-<number>`**.
+
+This branch name in the package version has a character limit of **12 characters**, so try to name your branch accordingly, otherwise it will be cut off.
 
 ## Building the package
 After cloning the repo, you may find many errors relating to the `Hackney.Core.Testing.PactBroker` project similar to the one below when attempting to build the solution **_on a Windows machine_**:


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/MTTL-2231

## Describe this PR

### *What is the problem we're trying to solve*

The pipeline currently fails when multiple people are working on the same package concurrently due to a conflict (a version of the package has been published already). This can be rectified by adding branch names to preview versions of NuGet packages.

### *What changes have we introduced*

- Updated the gitversion config to use branch names in versions
- Updated the readme with better contribution guidelines

#### _Checklist_

- [x] Added comments to the README or updated relevant documentation, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
