### PR TITLE
Fix SnsEventVerifier falsely passing E2E tests

### DIFF
--- a/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Sns/ISnsEventVerifier.cs
+++ b/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Sns/ISnsEventVerifier.cs
@@ -23,6 +23,7 @@ namespace Hackney.Core.Testing.Sns
         /// </param>
         /// <returns>true if a message in the temporary queue satisfies the verification function.
         /// false if no message in the temporary queue satisfies the verification function.</returns>
+        /// <exception cref="System.Exception">If no SQS messages are found.</exception>
         Task<bool> VerifySnsEventRaised<T>(Action<T> verifyFunction) where T : class;
 
         /// <summary>

--- a/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Sns/ISnsFixture.cs
+++ b/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Sns/ISnsFixture.cs
@@ -28,6 +28,8 @@ namespace Hackney.Core.Testing.Sns
         /// <returns><see cref="ISnsEventVerifier"/> reference or null</returns>
         ISnsEventVerifier GetSnsEventVerifier<T>() where T : class;
 
+        void PurgeAllQueueMessages();
+
         /// <summary>
         /// Creates the required Sns topic in the configured Sns instance. 
         /// Also creates an <see cref="SnsEventVerifier"/> for the topic.

--- a/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Sns/ISnsFixture.cs
+++ b/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Sns/ISnsFixture.cs
@@ -28,6 +28,10 @@ namespace Hackney.Core.Testing.Sns
         /// <returns><see cref="ISnsEventVerifier"/> reference or null</returns>
         ISnsEventVerifier GetSnsEventVerifier<T>() where T : class;
 
+        /// <summary>
+        /// Purges all messages from every queue used in each SnsEventVerifier.
+        /// </summary>
+        /// <returns>Task</returns>
         void PurgeAllQueueMessages();
 
         /// <summary>

--- a/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Sns/SnsEventVerifier.cs
+++ b/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Sns/SnsEventVerifier.cs
@@ -28,7 +28,6 @@ namespace Hackney.Core.Testing.Sns
         /// The last exception encountered whilst processing <see cref="ISnsEventVerifier.VerifySnsEventRaised{T}(Action{T})"/>
         /// </summary>
         public Exception LastException { get; private set; }
-        public int NumberOfResponses { get; private set; }
 
         /// <summary>
         /// Constructor
@@ -114,6 +113,7 @@ namespace Hackney.Core.Testing.Sns
         /// </param>
         /// <returns>true if a message in the temporary queue satisfies the verification function.
         /// false if no message in the temporary queue satisfies the verification function.</returns>
+        /// <exception cref="System.Exception">If no SQS messages are found.</exception>
         public async Task<bool> VerifySnsEventRaised<T>(Action<T> verifyFunction) where T : class
         {
             bool eventFound = false;
@@ -124,9 +124,7 @@ namespace Hackney.Core.Testing.Sns
             };
             var response = await _amazonSQS.ReceiveMessageAsync(request).ConfigureAwait(false);
 
-            NumberOfResponses = response.Messages.Count;
-
-            if (NumberOfResponses == 0)
+            if (response.Messages.Count == 0)
                 LastException = new Exception("No SQS messages received.");
 
             foreach (var msg in response.Messages)

--- a/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Sns/SnsEventVerifier.cs
+++ b/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Sns/SnsEventVerifier.cs
@@ -28,6 +28,7 @@ namespace Hackney.Core.Testing.Sns
         /// The last exception encountered whilst processing <see cref="ISnsEventVerifier.VerifySnsEventRaised{T}(Action{T})"/>
         /// </summary>
         public Exception LastException { get; private set; }
+        public int NumberOfResponses { get; private set; }
 
         /// <summary>
         /// Constructor
@@ -123,7 +124,9 @@ namespace Hackney.Core.Testing.Sns
             };
             var response = await _amazonSQS.ReceiveMessageAsync(request).ConfigureAwait(false);
 
-            if (response.Messages.Count == 0)
+            NumberOfResponses = response.Messages.Count;
+
+            if (NumberOfResponses == 0)
                 LastException = new Exception("No SQS messages received.");
 
             foreach (var msg in response.Messages)

--- a/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Sns/SnsEventVerifier.cs
+++ b/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Sns/SnsEventVerifier.cs
@@ -123,9 +123,9 @@ namespace Hackney.Core.Testing.Sns
             };
             var response = await _amazonSQS.ReceiveMessageAsync(request).ConfigureAwait(false);
 
-            if(response.Messages.Count == 0)
+            if (response.Messages.Count == 0)
                 LastException = new Exception("No SQS messages received.");
-            
+
             foreach (var msg in response.Messages)
             {
                 eventFound = IsExpectedMessage(msg, verifyFunction);

--- a/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Sns/SnsFixture.cs
+++ b/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Sns/SnsFixture.cs
@@ -51,6 +51,12 @@ namespace Hackney.Core.Testing.Sns
             }
         }
 
+        public void PurgeAllQueueMessages()
+        {
+            foreach (var verifier in _snsVerifers)
+                verifier.Value.PurgeQueueMessages();
+        }
+
         /// <summary>
         /// Retrieves the SnsEventVerifier appropriate to the specified event type.
         /// </summary>

--- a/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Sns/SnsFixture.cs
+++ b/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Sns/SnsFixture.cs
@@ -51,12 +51,6 @@ namespace Hackney.Core.Testing.Sns
             }
         }
 
-        public void PurgeAllQueueMessages()
-        {
-            foreach (var verifier in _snsVerifers)
-                verifier.Value.PurgeQueueMessages();
-        }
-
         /// <summary>
         /// Retrieves the SnsEventVerifier appropriate to the specified event type.
         /// </summary>
@@ -66,6 +60,16 @@ namespace Hackney.Core.Testing.Sns
         {
             var name = typeof(T).Name;
             return _snsVerifers.ContainsKey(name) ? _snsVerifers[name] : null;
+        }
+
+        /// <summary>
+        /// Purges all messages from every queue used in each SnsEventVerifier.
+        /// </summary>
+        /// <returns>Task</returns>
+        public void PurgeAllQueueMessages()
+        {
+            foreach (var verifier in _snsVerifers)
+                verifier.Value.PurgeQueueMessages();
         }
 
         /// <summary>

--- a/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Sns/SnsFixture.cs
+++ b/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Sns/SnsFixture.cs
@@ -78,8 +78,8 @@ namespace Hackney.Core.Testing.Sns
             if (string.IsNullOrEmpty(topicArnEnvVarName)) throw new ArgumentNullException(nameof(topicArnEnvVarName));
 
             snsAttrs = snsAttrs ?? new Dictionary<string, string>();
-            snsAttrs.Add("fifo_topic", "true");
-            snsAttrs.Add("content_based_deduplication", "true");
+            snsAttrs.Add("FifoTopic", "true");
+            snsAttrs.Add("ContentBasedDeduplication", "true");
 
             var response = SimpleNotificationService.CreateTopicAsync(new CreateTopicRequest
             {


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

During work on Processes API, I noticed that the E2E tests involving events always passed, when they shouldn't have.

### *What changes have we introduced*

- Ensure that SNS topics and SQS queues created for the tests are marked as `first-in-first-out` to avoid SNS messages not being forwarded to the queue correctly.
- Add the `PurgeAllQueueMessages` method to the SnsFixture, which needs to be added as a cleanup action to test classes.
- Add a new exception so that an error is thrown if no messages are received (previously this would falsely pass)

#### _Checklist_

- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Check on APIs that use this package, as their E2E tests may fail after updating the package.