### PR TITLE
Introduce BestFields for ElasticSearch

### DIFF
--- a/Hackney.Core.Tests/Hackney.Core.Tests.ElasticSearch/QueryBuilderTests.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.ElasticSearch/QueryBuilderTests.cs
@@ -65,17 +65,4 @@ namespace Hackney.Core.Tests.ElasticSearch
             Assert.Equal(1, container.Count(q => q != null));
         }
     }
-
-    public class MatchQueryVisitor : QueryVisitor
-    {
-        public string Field { get; set; }
-        public string Value { get; set; }
-        public override void Visit(IMatchQuery query)
-        {
-            var inferrer = new Inferrer(new ConnectionSettings(new InMemoryConnection()));
-            Field = inferrer.Field(query.Field);
-            Value = query.Query;
-
-        }
-    }
 }

--- a/Hackney.Core.Tests/Hackney.Core.Tests.ElasticSearch/QueryBuilderTests.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.ElasticSearch/QueryBuilderTests.cs
@@ -1,15 +1,80 @@
+using Elasticsearch.Net;
+using Hackney.Core.ElasticSearch;
+using Hackney.Core.ElasticSearch.Interfaces;
+using Moq;
+using Nest;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace Hackney.Core.Tests.ElasticSearch
 {
     public class QueryBuilderTests
     {
-        // TODO
+        private readonly QueryBuilder<TestSearchObject> _sut;
+        private readonly Mock<IWildCardAppenderAndPrepender> _wildcardAppenderAndPrependerMock;
+        private readonly QueryContainerDescriptor<TestSearchObject> _queryContainerDesc;
+        public QueryBuilderTests()
+        {
+            _wildcardAppenderAndPrependerMock = new Mock<IWildCardAppenderAndPrepender>();
+            _queryContainerDesc = new QueryContainerDescriptor<TestSearchObject>();
+
+            _sut = new QueryBuilder<TestSearchObject>(_wildcardAppenderAndPrependerMock.Object);
+        }
+
+        [Theory]
+        [InlineData(TextQueryType.BestFields)]
+        [InlineData(TextQueryType.MostFields)]
+        public void WhenCreatingQuery_WithSpecifiedType_ResultantQueryShouldBeThatType(TextQueryType queryType)
+        {
+            // Arrange 
+            string searchText = "4 Annerdale House";
+            var fields = new List<string> { "field1", "field2" };
+            _wildcardAppenderAndPrependerMock.Setup(x => x.Process(It.IsAny<string>()))
+                .Returns(new List<string> { "*4*", "*Annerdale*", "*House*" });
+
+            // Act
+            QueryContainer query = _sut.WithWildstarQuery(searchText, fields, queryType)
+                .Build(_queryContainerDesc);
+
+            // Assert
+            var container = (query as IQueryContainer).Bool.Should.First() as IQueryContainer;
+
+            Assert.Equal(queryType, container.QueryString.Type);
+        }
 
         [Fact]
-        public void Test1()
+        public void WhenCreatingQuery_WithWildstar_ResultantQueryShouldHaveOneSubquery()
         {
+            // Arrange 
+            string searchText = "12 Pitcairn Street";
+            var fields = new List<string> { "field1", "field2" };
+            _wildcardAppenderAndPrependerMock.Setup(x => x.Process(It.IsAny<string>()))
+                .Returns(new List<string> { "*12*", "*Pitcairn*", "*Street*" });
+
+            // Act
+            QueryContainer query = _sut.WithWildstarQuery(searchText, fields)
+                .Build(_queryContainerDesc);
+
+            // Assert
+            var container = (query as IQueryContainer).Bool.Should;
+
+            Assert.Equal(2, container.Count());
+            Assert.Equal(1, container.Count(q => q != null));
+        }
+    }
+
+    public class MatchQueryVisitor : QueryVisitor
+    {
+        public string Field { get; set; }
+        public string Value { get; set; }
+        public override void Visit(IMatchQuery query)
+        {
+            var inferrer = new Inferrer(new ConnectionSettings(new InMemoryConnection()));
+            Field = inferrer.Field(query.Field);
+            Value = query.Query;
 
         }
     }

--- a/Hackney.Core.Tests/Hackney.Core.Tests.ElasticSearch/TestSearchObject.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.ElasticSearch/TestSearchObject.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Hackney.Core.Tests.ElasticSearch
+{
+    public class TestSearchObject
+    {
+        // Generic class for testing QueryBuilder
+    }
+}

--- a/Hackney.Core.Tests/Hackney.Core.Tests.Validation.AspNet/UseErrorCodeInterceptorTests.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.Validation.AspNet/UseErrorCodeInterceptorTests.cs
@@ -41,7 +41,7 @@ namespace Hackney.Core.Tests.Validation.AspNet
             return options;
         }
 
-        private IEnumerable<ValidationFailure> ConstructFailures()
+        private static IEnumerable<ValidationFailure> ConstructFailures()
         {
             var failures = new List<ValidationFailure>();
             for (int i = 1; i < 5; i++)

--- a/Hackney.Core/Hackney.Core.Authorization/BaseErrorResponse.cs
+++ b/Hackney.Core/Hackney.Core.Authorization/BaseErrorResponse.cs
@@ -4,7 +4,7 @@
     {
         public BaseErrorResponse() { }
 
-        public BaseErrorResponse(int statusCode, string message, string details = null)
+        public BaseErrorResponse(int statusCode, string message, string? details = null)
         {
             StatusCode = statusCode;
             Message = message;

--- a/Hackney.Core/Hackney.Core.ElasticSearch/Interfaces/IQueryBuilder.cs
+++ b/Hackney.Core/Hackney.Core.ElasticSearch/Interfaces/IQueryBuilder.cs
@@ -5,11 +5,11 @@ namespace Hackney.Core.ElasticSearch.Interfaces
 {
     public interface IQueryBuilder<T> where T : class
     {
-        public IQueryBuilder<T> WithWildstarQuery(string searchText, List<string> fields);
+        public IQueryBuilder<T> WithWildstarQuery(string searchText, List<string> fields, TextQueryType textQueryType = TextQueryType.MostFields);
 
-        public IQueryBuilder<T> WithFilterQuery(string commaSeparatedFilters, List<string> fields);
+        public IQueryBuilder<T> WithFilterQuery(string commaSeparatedFilters, List<string> fields, TextQueryType textQueryType = TextQueryType.MostFields);
 
-        public IQueryBuilder<T> WithExactQuery(string searchText, List<string> fields, IExactSearchQuerystringProcessor processor = null);
+        public IQueryBuilder<T> WithExactQuery(string searchText, List<string> fields, IExactSearchQuerystringProcessor processor = null, TextQueryType textQueryType = TextQueryType.MostFields);
 
         public QueryContainer Build(QueryContainerDescriptor<T> containerDescriptor);
     }


### PR DESCRIPTION
- ElasticSearch has thus far relied exclusively on MOST_FIELDs logic when searching indexes
- This isn't ideal for searching through address data
- Address data is better off using a different comparison, BEST_FIELDS

Take the following examples:

GET addresses/_search
{
"query": {
"multi_match": {
  "query": "4 Annerdale Drive",
  "fields": ["assetAddress.addressLine1", "assetAddress.postCode", "assetAddress.uprn"],
  "type": "most_fields"
   }
  }
}

In the above query, the original implementation, the _score is dictated by the **sum** of the scores for all the fields - this is poor match for address searching because this query phrase is likely to score very poorly in postcode and UPRN

GET addresses/_search
{
"query": {
"multi_match": {
  "query": "4 Annerdale Drive",
  "fields": ["assetAddress.addressLine1", "assetAddress.postCode", "assetAddress.uprn"],
  "type": "best_fields"
   }
  }
}

In the above query, the new implementation, the overall match _score will be dictated the single **largest** score from any of the fields (i.e. it's very likely to be address line 1 in this example)

