### PR TITLE
Let APIs have multiple DynamoDB healthchecks

### DIFF
--- a/Hackney.Core.Tests/Hackney.Core.Tests.DynamoDb/HealthCheck/DynamoDbHealthCheckExtensionsTests.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.DynamoDb/HealthCheck/DynamoDbHealthCheckExtensionsTests.cs
@@ -38,7 +38,7 @@ namespace Hackney.Core.Tests.DynamoDb.HealthCheck
             var mockBuilder = new Mock<IHealthChecksBuilder>();
             _ = mockBuilder.Object.AddDynamoDbHealthCheck<TestModelDb>();
 
-            mockBuilder.Verify(x => x.Add(It.Is<HealthCheckRegistration>(hcr => hcr.Name == "DynamoDb"
+            mockBuilder.Verify(x => x.Add(It.Is<HealthCheckRegistration>(hcr => hcr.Name == "DynamoDb_" + typeof(TestModelDb).Name
                                                                              && hcr.Factory != null)), Times.Once);
         }
     }

--- a/Hackney.Core/Hackney.Core.DynamoDb/HealthCheck/DynamoDbHealthCheckExtensions.cs
+++ b/Hackney.Core/Hackney.Core.DynamoDb/HealthCheck/DynamoDbHealthCheckExtensions.cs
@@ -5,7 +5,7 @@ namespace Hackney.Core.DynamoDb.HealthCheck
 {
     public static class DynamoDbHealthCheckExtensions
     {
-        private const string Name = "DynamoDb";
+        private const string Name = "DynamoDb_";
 
         public static IServiceCollection RegisterDynamoDbHealthCheck<T>(this IServiceCollection services) where T : class
         {
@@ -14,7 +14,7 @@ namespace Hackney.Core.DynamoDb.HealthCheck
 
         public static IHealthChecksBuilder AddDynamoDbHealthCheck<T>(this IHealthChecksBuilder builder) where T : class
         {
-            return builder.AddCheck<DynamoDbHealthCheck<T>>(Name);
+            return builder.AddCheck<DynamoDbHealthCheck<T>>(Name + typeof(T).Name);
         }
 
         /// <summary>


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

Currently, APIs which utilise multiple DynamoDB tables cannot have health checks for all tables. This tweak allows them to be used for multiple tables.