### PR TITLE
Feature/ts 1466 newly created temp accommodation does not appear in search

### DIFF
--- a/Hackney.Core.Tests/Hackney.Core.Tests.ElasticSearch/QueryBuilderTests.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.ElasticSearch/QueryBuilderTests.cs
@@ -66,6 +66,26 @@ namespace Hackney.Core.Tests.ElasticSearch
         }
 
         [Fact]
+        public void WhenCreatingQuery_WithWildstarBool_ResultantQueryShouldHaveOneSubquery()
+        {
+            // Arrange 
+            string searchText = "8 Westminster Lane";
+            var fields = new List<string> { "field1", "field2" };
+            _wildcardAppenderAndPrependerMock.Setup(x => x.Process(It.IsAny<string>()))
+                .Returns(new List<string> { "*8*", "*Westminster*", "*Lane*" });
+
+            // Act
+            QueryContainer query = _sut.WithWildstarBoolQuery(searchText, fields)
+                .Build(_queryContainerDesc);
+
+            // Assert
+            var container = (query as IQueryContainer).Bool.Should;
+
+            Assert.Equal(2, container.Count());
+            Assert.Equal(1, container.Count(q => q != null));
+        }
+
+        [Fact]
         public void WhenCreatingSimpleQuery_WithWildstar_ResultantQueryBeOfSimpleType()
         {
             // Arrange 

--- a/Hackney.Core/Hackney.Core.ElasticSearch/Interfaces/IQueryBuilder.cs
+++ b/Hackney.Core/Hackney.Core.ElasticSearch/Interfaces/IQueryBuilder.cs
@@ -7,8 +7,6 @@ namespace Hackney.Core.ElasticSearch.Interfaces
     {
         public IQueryBuilder<T> WithWildstarQuery(string searchText, List<string> fields, TextQueryType textQueryType = TextQueryType.MostFields);
 
-        public IQueryBuilder<T> WithWildstarBoolQuery(string searchText, List<string> fields, int? minimumShouldMatch = null, TextQueryType textQueryType = TextQueryType.MostFields);
-
         public IQueryBuilder<T> WithFilterQuery(string commaSeparatedFilters, List<string> fields, TextQueryType textQueryType = TextQueryType.MostFields);
 
         public IQueryBuilder<T> WithExactQuery(string searchText, List<string> fields, IExactSearchQuerystringProcessor processor = null, TextQueryType textQueryType = TextQueryType.MostFields);

--- a/Hackney.Core/Hackney.Core.ElasticSearch/Interfaces/IQueryBuilder.cs
+++ b/Hackney.Core/Hackney.Core.ElasticSearch/Interfaces/IQueryBuilder.cs
@@ -7,6 +7,8 @@ namespace Hackney.Core.ElasticSearch.Interfaces
     {
         public IQueryBuilder<T> WithWildstarQuery(string searchText, List<string> fields, TextQueryType textQueryType = TextQueryType.MostFields);
 
+        public IQueryBuilder<T> WithWildstarBoolQuery(string searchText, List<string> fields, int? minimumShouldMatch = null, TextQueryType textQueryType = TextQueryType.MostFields);
+
         public IQueryBuilder<T> WithFilterQuery(string commaSeparatedFilters, List<string> fields, TextQueryType textQueryType = TextQueryType.MostFields);
 
         public IQueryBuilder<T> WithExactQuery(string searchText, List<string> fields, IExactSearchQuerystringProcessor processor = null, TextQueryType textQueryType = TextQueryType.MostFields);


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1466?atlOrigin=eyJpIjoiNTk1MDEwMDJlMjg4NGI4ZjhlZDMzMjJkNjg4MmU5NjMiLCJwIjoiaiJ9

## Describe this PR

### *What is the problem we're trying to solve*

I want to be able to make a query that can test a split wildcard property (i.e. *123* & *example*) is both true on a field.

### *What changes have we introduced*

Adds a method that allows for individual boolean wildcard queries on an elastic search. 

#### _Checklist_

- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Will be implemented in the search-api as https://github.com/LBHackney-IT/housing-search-api/pull/230
