### PR TITLE
Use GITHUB_TOKEN for NuGet packages in GitHub Actions

### DIFF
--- a/.github/workflows-template/publish.yml
+++ b/.github/workflows-template/publish.yml
@@ -12,8 +12,6 @@ jobs:
   calculate-version:
     name: Calculate Version
     runs-on: ubuntu-latest
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -38,8 +36,6 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows-template/publish.yml
+++ b/.github/workflows-template/publish.yml
@@ -60,9 +60,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
-        run: docker-compose build hackney-core-<PACKAGE_NAME_LOWERCASE>-test
+        run: docker compose build hackney-core-<PACKAGE_NAME_LOWERCASE>-test
       - name: Run tests
-        run: docker-compose run hackney-core-<PACKAGE_NAME_LOWERCASE>-test
+        run: docker compose run hackney-core-<PACKAGE_NAME_LOWERCASE>-test
 
   publish-package:
     name: Publish Package

--- a/.github/workflows-template/publish.yml
+++ b/.github/workflows-template/publish.yml
@@ -13,7 +13,7 @@ jobs:
     name: Calculate Version
     runs-on: ubuntu-latest
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ needs.calculate-version.outputs.version }}
     steps:
@@ -74,7 +74,7 @@ jobs:
     needs: build-and-test
     env:
       VERSION: ${{ needs.build-and-test.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -85,4 +85,4 @@ jobs:
       - name: Publish the Package
         run: |
           cd Hackney.Core/<PACKAGE_NAME>/bin/Release
-          dotnet nuget push <PACKAGE_NAME>.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.NUGET_KEY }}
+          dotnet nuget push <PACKAGE_NAME>.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Hackney.Core.Authorization.yml
+++ b/.github/workflows/Hackney.Core.Authorization.yml
@@ -60,9 +60,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
-        run: docker-compose build hackney-core-authorization-test
+        run: docker compose build hackney-core-authorization-test
       - name: Run tests
-        run: docker-compose run hackney-core-authorization-test
+        run: docker compose run hackney-core-authorization-test
 
   publish-authorization-package:
     name: Publish Authorization Package

--- a/.github/workflows/Hackney.Core.Authorization.yml
+++ b/.github/workflows/Hackney.Core.Authorization.yml
@@ -13,7 +13,7 @@ jobs:
     name: Calculate Version
     runs-on: ubuntu-latest
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ needs.calculate-version.outputs.version }}
     steps:
@@ -76,7 +76,7 @@ jobs:
       - build-and-test
     env:
       VERSION: ${{ needs.build-and-test.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -87,4 +87,4 @@ jobs:
       - name: Publish the Package
         run: |
           cd Hackney.Core/Hackney.Core.Authorization/bin/Release
-          dotnet nuget push Hackney.Core.Authorization.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.NUGET_KEY }}
+          dotnet nuget push Hackney.Core.Authorization.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Hackney.Core.Authorization.yml
+++ b/.github/workflows/Hackney.Core.Authorization.yml
@@ -12,8 +12,6 @@ jobs:
   calculate-version:
     name: Calculate Version
     runs-on: ubuntu-latest
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -38,8 +36,6 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Hackney.Core.DynamoDb.yml
+++ b/.github/workflows/Hackney.Core.DynamoDb.yml
@@ -12,8 +12,6 @@ jobs:
   calculate-version:
     name: Calculate Version
     runs-on: ubuntu-latest
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -38,8 +36,6 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Hackney.Core.DynamoDb.yml
+++ b/.github/workflows/Hackney.Core.DynamoDb.yml
@@ -60,9 +60,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
-        run: docker-compose build hackney-core-dynamodb-test
+        run: docker compose build hackney-core-dynamodb-test
       - name: Run tests
-        run: docker-compose run hackney-core-dynamodb-test
+        run: docker compose run hackney-core-dynamodb-test
 
   publish-package:
     name: Publish Package

--- a/.github/workflows/Hackney.Core.DynamoDb.yml
+++ b/.github/workflows/Hackney.Core.DynamoDb.yml
@@ -13,7 +13,7 @@ jobs:
     name: Calculate Version
     runs-on: ubuntu-latest
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ needs.calculate-version.outputs.version }}
     steps:
@@ -74,7 +74,7 @@ jobs:
     needs: build-and-test
     env:
       VERSION: ${{ needs.build-and-test.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -85,4 +85,4 @@ jobs:
       - name: Publish the Package
         run: |
           cd Hackney.Core/Hackney.Core.DynamoDb/bin/Release
-          dotnet nuget push Hackney.Core.DynamoDb.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.NUGET_KEY }}
+          dotnet nuget push Hackney.Core.DynamoDb.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Hackney.Core.ElasticSearch.yml
+++ b/.github/workflows/Hackney.Core.ElasticSearch.yml
@@ -60,9 +60,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
-        run: docker-compose build hackney-core-elasticsearch-test
+        run: docker compose build hackney-core-elasticsearch-test
       - name: Run tests
-        run: docker-compose run hackney-core-elasticsearch-test
+        run: docker compose run hackney-core-elasticsearch-test
 
   publish-package:
     name: Publish Package

--- a/.github/workflows/Hackney.Core.ElasticSearch.yml
+++ b/.github/workflows/Hackney.Core.ElasticSearch.yml
@@ -12,8 +12,6 @@ jobs:
   calculate-version:
     name: Calculate Version
     runs-on: ubuntu-latest
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -38,8 +36,6 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -60,7 +56,6 @@ jobs:
       LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ needs.calculate-version.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Hackney.Core.ElasticSearch.yml
+++ b/.github/workflows/Hackney.Core.ElasticSearch.yml
@@ -13,7 +13,7 @@ jobs:
     name: Calculate Version
     runs-on: ubuntu-latest
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,10 +57,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ needs.calculate-version.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-test
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
       VERSION: ${{ needs.build-and-test.outputs.version }}
     steps:
       - name: Checkout
@@ -86,4 +86,4 @@ jobs:
       - name: Publish the Package
         run: |
           cd Hackney.Core/Hackney.Core.ElasticSearch/bin/Release
-          dotnet nuget push Hackney.Core.ElasticSearch.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.NUGET_KEY }}
+          dotnet nuget push Hackney.Core.ElasticSearch.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Hackney.Core.Enums.yml
+++ b/.github/workflows/Hackney.Core.Enums.yml
@@ -13,7 +13,7 @@ jobs:
     name: Calculate Version
     runs-on: ubuntu-latest
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ needs.calculate-version.outputs.version }}
     steps:
@@ -74,7 +74,7 @@ jobs:
     needs: build-and-test
     env:
       VERSION: ${{ needs.build-and-test.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -85,4 +85,4 @@ jobs:
       - name: Publish the Package
         run: |
           cd Hackney.Core/Hackney.Core.Enums/bin/Release
-          dotnet nuget push Hackney.Core.Enums.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.NUGET_KEY }}
+          dotnet nuget push Hackney.Core.Enums.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Hackney.Core.Enums.yml
+++ b/.github/workflows/Hackney.Core.Enums.yml
@@ -60,9 +60,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
-        run: docker-compose build hackney-core-enums-test
+        run: docker compose build hackney-core-enums-test
       - name: Run tests
-        run: docker-compose run hackney-core-enums-test
+        run: docker compose run hackney-core-enums-test
 
   publish-package:
     name: Publish Package

--- a/.github/workflows/Hackney.Core.Enums.yml
+++ b/.github/workflows/Hackney.Core.Enums.yml
@@ -12,8 +12,6 @@ jobs:
   calculate-version:
     name: Calculate Version
     runs-on: ubuntu-latest
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -38,8 +36,6 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Hackney.Core.HealthCheck.yml
+++ b/.github/workflows/Hackney.Core.HealthCheck.yml
@@ -13,7 +13,7 @@ jobs:
     name: Calculate Version
     runs-on: ubuntu-latest
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ needs.calculate-version.outputs.version }}
     steps:
@@ -74,7 +74,7 @@ jobs:
     needs: build-and-test
     env:
       VERSION: ${{ needs.build-and-test.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -85,4 +85,4 @@ jobs:
       - name: Publish the Package
         run: |
           cd Hackney.Core/Hackney.Core.HealthCheck/bin/Release
-          dotnet nuget push Hackney.Core.HealthCheck.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.NUGET_KEY }}
+          dotnet nuget push Hackney.Core.HealthCheck.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Hackney.Core.HealthCheck.yml
+++ b/.github/workflows/Hackney.Core.HealthCheck.yml
@@ -60,9 +60,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
-        run: docker-compose build hackney-core-healthcheck-test
+        run: docker compose build hackney-core-healthcheck-test
       - name: Run tests
-        run: docker-compose run hackney-core-healthcheck-test
+        run: docker compose run hackney-core-healthcheck-test
 
   publish-package:
     name: Publish Package

--- a/.github/workflows/Hackney.Core.HealthCheck.yml
+++ b/.github/workflows/Hackney.Core.HealthCheck.yml
@@ -12,8 +12,6 @@ jobs:
   calculate-version:
     name: Calculate Version
     runs-on: ubuntu-latest
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -38,8 +36,6 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Hackney.Core.Http.yml
+++ b/.github/workflows/Hackney.Core.Http.yml
@@ -13,7 +13,7 @@ jobs:
     name: Calculate Version
     runs-on: ubuntu-latest
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -59,7 +59,7 @@ jobs:
     outputs:
       version: ${{ needs.calculate-version.outputs.version }}
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -74,7 +74,7 @@ jobs:
     needs: build-and-test
     env:
       VERSION: ${{ needs.build-and-test.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -85,4 +85,4 @@ jobs:
       - name: Publish the Package
         run: |
           cd Hackney.Core/Hackney.Core.Http/bin/Release
-          dotnet nuget push Hackney.Core.Http.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.NUGET_KEY }}
+          dotnet nuget push Hackney.Core.Http.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Hackney.Core.Http.yml
+++ b/.github/workflows/Hackney.Core.Http.yml
@@ -12,8 +12,6 @@ jobs:
   calculate-version:
     name: Calculate Version
     runs-on: ubuntu-latest
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -38,8 +36,6 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Hackney.Core.Http.yml
+++ b/.github/workflows/Hackney.Core.Http.yml
@@ -60,9 +60,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
-        run: docker-compose build hackney-core-http-test
+        run: docker compose build hackney-core-http-test
       - name: Run tests
-        run: docker-compose run hackney-core-http-test
+        run: docker compose run hackney-core-http-test
 
   publish-package:
     name: Publish Package

--- a/.github/workflows/Hackney.Core.JWT.yml
+++ b/.github/workflows/Hackney.Core.JWT.yml
@@ -13,7 +13,7 @@ jobs:
     name: Calculate Version
     runs-on: ubuntu-latest
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,10 +57,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ needs.calculate-version.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -75,7 +75,7 @@ jobs:
     needs: build-and-test
     env:
       VERSION: ${{ needs.build-and-test.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -86,4 +86,4 @@ jobs:
       - name: Publish the Package
         run: |
           cd Hackney.Core/Hackney.Core.JWT/bin/Release
-          dotnet nuget push Hackney.Core.JWT.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.NUGET_KEY }}
+          dotnet nuget push Hackney.Core.JWT.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Hackney.Core.JWT.yml
+++ b/.github/workflows/Hackney.Core.JWT.yml
@@ -60,9 +60,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
-        run: docker-compose build hackney-core-jwt-test
+        run: docker compose build hackney-core-jwt-test
       - name: Run tests
-        run: docker-compose run hackney-core-jwt-test
+        run: docker compose run hackney-core-jwt-test
 
   publish-package:
     name: Publish Package

--- a/.github/workflows/Hackney.Core.JWT.yml
+++ b/.github/workflows/Hackney.Core.JWT.yml
@@ -12,8 +12,6 @@ jobs:
   calculate-version:
     name: Calculate Version
     runs-on: ubuntu-latest
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -38,8 +36,6 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -60,7 +56,6 @@ jobs:
       LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ needs.calculate-version.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Hackney.Core.Logging.yml
+++ b/.github/workflows/Hackney.Core.Logging.yml
@@ -13,7 +13,7 @@ jobs:
     name: Calculate Version
     runs-on: ubuntu-latest
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ needs.calculate-version.outputs.version }}
     steps:
@@ -74,7 +74,7 @@ jobs:
     needs: build-and-test
     env:
       VERSION: ${{ needs.build-and-test.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -85,4 +85,4 @@ jobs:
       - name: Publish the Package
         run: |
           cd Hackney.Core/Hackney.Core.Logging/bin/Release
-          dotnet nuget push Hackney.Core.Logging.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.NUGET_KEY }}
+          dotnet nuget push Hackney.Core.Logging.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Hackney.Core.Logging.yml
+++ b/.github/workflows/Hackney.Core.Logging.yml
@@ -12,8 +12,6 @@ jobs:
   calculate-version:
     name: Calculate Version
     runs-on: ubuntu-latest
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -38,8 +36,6 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Hackney.Core.Logging.yml
+++ b/.github/workflows/Hackney.Core.Logging.yml
@@ -60,9 +60,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
-        run: docker-compose build hackney-core-logging-test
+        run: docker compose build hackney-core-logging-test
       - name: Run tests
-        run: docker-compose run hackney-core-logging-test
+        run: docker compose run hackney-core-logging-test
 
   publish-package:
     name: Publish Package

--- a/.github/workflows/Hackney.Core.Middleware.yml
+++ b/.github/workflows/Hackney.Core.Middleware.yml
@@ -12,8 +12,6 @@ jobs:
   calculate-version:
     name: Calculate Version
     runs-on: ubuntu-latest
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -38,8 +36,6 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Hackney.Core.Middleware.yml
+++ b/.github/workflows/Hackney.Core.Middleware.yml
@@ -60,9 +60,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
-        run: docker-compose build hackney-core-middleware-test
+        run: docker compose build hackney-core-middleware-test
       - name: Run tests
-        run: docker-compose run hackney-core-middleware-test
+        run: docker compose run hackney-core-middleware-test
 
   publish-package:
     name: Publish Package

--- a/.github/workflows/Hackney.Core.Middleware.yml
+++ b/.github/workflows/Hackney.Core.Middleware.yml
@@ -13,7 +13,7 @@ jobs:
     name: Calculate Version
     runs-on: ubuntu-latest
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ needs.calculate-version.outputs.version }}
     steps:
@@ -74,7 +74,7 @@ jobs:
     needs: build-and-test
     env:
       VERSION: ${{ needs.build-and-test.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -85,4 +85,4 @@ jobs:
       - name: Publish the Package
         run: |
           cd Hackney.Core/Hackney.Core.Middleware/bin/Release
-          dotnet nuget push Hackney.Core.Middleware.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.NUGET_KEY }}
+          dotnet nuget push Hackney.Core.Middleware.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Hackney.Core.Sns.yml
+++ b/.github/workflows/Hackney.Core.Sns.yml
@@ -60,9 +60,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
-        run: docker-compose build hackney-core-sns-test
+        run: docker compose build hackney-core-sns-test
       - name: Run tests
-        run: docker-compose run hackney-core-sns-test
+        run: docker compose run hackney-core-sns-test
 
   publish-package:
     name: Publish Package

--- a/.github/workflows/Hackney.Core.Sns.yml
+++ b/.github/workflows/Hackney.Core.Sns.yml
@@ -12,8 +12,6 @@ jobs:
   calculate-version:
     name: Calculate Version
     runs-on: ubuntu-latest
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -38,8 +36,6 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Hackney.Core.Sns.yml
+++ b/.github/workflows/Hackney.Core.Sns.yml
@@ -13,7 +13,7 @@ jobs:
     name: Calculate Version
     runs-on: ubuntu-latest
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ needs.calculate-version.outputs.version }}
     steps:
@@ -74,7 +74,7 @@ jobs:
     needs: build-and-test
     env:
       VERSION: ${{ needs.build-and-test.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -85,4 +85,4 @@ jobs:
       - name: Publish the Package
         run: |
           cd Hackney.Core/Hackney.Core.Sns/bin/Release
-          dotnet nuget push Hackney.Core.Sns.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.NUGET_KEY }}
+          dotnet nuget push Hackney.Core.Sns.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Hackney.Core.Testing.DynamoDb.yml
+++ b/.github/workflows/Hackney.Core.Testing.DynamoDb.yml
@@ -12,7 +12,7 @@ jobs:
     name: Calculate Version
     runs-on: ubuntu-latest
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
     needs: calculate-version
     env:
       VERSION: ${{ needs.calculate-version.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -68,4 +68,4 @@ jobs:
       - name: Publish the Package
         run: |
           cd Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.DynamoDb/bin/Release
-          dotnet nuget push Hackney.Core.Testing.DynamoDb.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.NUGET_KEY }}
+          dotnet nuget push Hackney.Core.Testing.DynamoDb.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Hackney.Core.Testing.DynamoDb.yml
+++ b/.github/workflows/Hackney.Core.Testing.DynamoDb.yml
@@ -11,8 +11,6 @@ jobs:
   calculate-version:
     name: Calculate Version
     runs-on: ubuntu-latest
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -37,8 +35,6 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Hackney.Core.Testing.ElasticSearch.yml
+++ b/.github/workflows/Hackney.Core.Testing.ElasticSearch.yml
@@ -12,7 +12,7 @@ jobs:
     name: Calculate Version
     runs-on: ubuntu-latest
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
     needs: calculate-version
     env:
       VERSION: ${{ needs.calculate-version.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -68,4 +68,4 @@ jobs:
       - name: Publish the Package
         run: |
           cd Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.ElasticSearch/bin/Release
-          dotnet nuget push Hackney.Core.Testing.ElasticSearch.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.NUGET_KEY }}
+          dotnet nuget push Hackney.Core.Testing.ElasticSearch.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Hackney.Core.Testing.ElasticSearch.yml
+++ b/.github/workflows/Hackney.Core.Testing.ElasticSearch.yml
@@ -11,8 +11,6 @@ jobs:
   calculate-version:
     name: Calculate Version
     runs-on: ubuntu-latest
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -37,8 +35,6 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Hackney.Core.Testing.PactBroker.yml
+++ b/.github/workflows/Hackney.Core.Testing.PactBroker.yml
@@ -12,7 +12,7 @@ jobs:
     name: Calculate Version
     runs-on: ubuntu-latest
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
     needs: calculate-version
     env:
       VERSION: ${{ needs.calculate-version.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -68,4 +68,4 @@ jobs:
       - name: Publish the Package
         run: |
           cd Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.PactBroker/bin/Release
-          dotnet nuget push Hackney.Core.Testing.PactBroker.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.NUGET_KEY }}
+          dotnet nuget push Hackney.Core.Testing.PactBroker.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Hackney.Core.Testing.PactBroker.yml
+++ b/.github/workflows/Hackney.Core.Testing.PactBroker.yml
@@ -11,8 +11,6 @@ jobs:
   calculate-version:
     name: Calculate Version
     runs-on: ubuntu-latest
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -37,8 +35,6 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Hackney.Core.Testing.Shared.yml
+++ b/.github/workflows/Hackney.Core.Testing.Shared.yml
@@ -12,7 +12,7 @@ jobs:
     name: Calculate Version
     runs-on: ubuntu-latest
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
     needs: calculate-version
     env:
       VERSION: ${{ needs.calculate-version.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -68,4 +68,4 @@ jobs:
       - name: Publish the Package
         run: |
           cd Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/bin/Release
-          dotnet nuget push Hackney.Core.Testing.Shared.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.NUGET_KEY }}
+          dotnet nuget push Hackney.Core.Testing.Shared.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Hackney.Core.Testing.Shared.yml
+++ b/.github/workflows/Hackney.Core.Testing.Shared.yml
@@ -11,8 +11,6 @@ jobs:
   calculate-version:
     name: Calculate Version
     runs-on: ubuntu-latest
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -37,8 +35,6 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Hackney.Core.Testing.Sns.yml
+++ b/.github/workflows/Hackney.Core.Testing.Sns.yml
@@ -11,8 +11,6 @@ jobs:
   calculate-version:
     name: Calculate Version
     runs-on: ubuntu-latest
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -37,8 +35,6 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Hackney.Core.Testing.Sns.yml
+++ b/.github/workflows/Hackney.Core.Testing.Sns.yml
@@ -12,7 +12,7 @@ jobs:
     name: Calculate Version
     runs-on: ubuntu-latest
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
     needs: calculate-version
     env:
       VERSION: ${{ needs.calculate-version.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -68,4 +68,4 @@ jobs:
       - name: Publish the Package
         run: |
           cd Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Sns/bin/Release
-          dotnet nuget push Hackney.Core.Testing.Sns.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.NUGET_KEY }}
+          dotnet nuget push Hackney.Core.Testing.Sns.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Hackney.Core.Validation.AspNet.yml
+++ b/.github/workflows/Hackney.Core.Validation.AspNet.yml
@@ -60,9 +60,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
-        run: docker-compose build hackney-core-validation-aspnet-test
+        run: docker compose build hackney-core-validation-aspnet-test
       - name: Run tests
-        run: docker-compose run hackney-core-validation-aspnet-test
+        run: docker compose run hackney-core-validation-aspnet-test
 
   publish-package:
     name: Publish Package

--- a/.github/workflows/Hackney.Core.Validation.AspNet.yml
+++ b/.github/workflows/Hackney.Core.Validation.AspNet.yml
@@ -12,8 +12,6 @@ jobs:
   calculate-version:
     name: Calculate Version
     runs-on: ubuntu-latest
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -38,8 +36,6 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Hackney.Core.Validation.AspNet.yml
+++ b/.github/workflows/Hackney.Core.Validation.AspNet.yml
@@ -13,7 +13,7 @@ jobs:
     name: Calculate Version
     runs-on: ubuntu-latest
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ needs.calculate-version.outputs.version }}
     steps:
@@ -74,7 +74,7 @@ jobs:
     needs: build-and-test
     env:
       VERSION: ${{ needs.build-and-test.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -85,4 +85,4 @@ jobs:
       - name: Publish the Package
         run: |
           cd Hackney.Core/Hackney.Core.Validation.AspNet/bin/Release
-          dotnet nuget push Hackney.Core.Validation.AspNet.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.NUGET_KEY }}
+          dotnet nuget push Hackney.Core.Validation.AspNet.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Hackney.Core.Validation.yml
+++ b/.github/workflows/Hackney.Core.Validation.yml
@@ -13,7 +13,7 @@ jobs:
     name: Calculate Version
     runs-on: ubuntu-latest
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ needs.calculate-version.outputs.version }}
     steps:
@@ -74,7 +74,7 @@ jobs:
     needs: build-and-test
     env:
       VERSION: ${{ needs.build-and-test.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -85,4 +85,4 @@ jobs:
       - name: Publish the Package
         run: |
           cd Hackney.Core/Hackney.Core.Validation/bin/Release
-          dotnet nuget push Hackney.Core.Validation.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.NUGET_KEY }}
+          dotnet nuget push Hackney.Core.Validation.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Hackney.Core.Validation.yml
+++ b/.github/workflows/Hackney.Core.Validation.yml
@@ -60,9 +60,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
-        run: docker-compose build hackney-core-validation-test
+        run: docker compose build hackney-core-validation-test
       - name: Run tests
-        run: docker-compose run hackney-core-validation-test
+        run: docker compose run hackney-core-validation-test
 
   publish-package:
     name: Publish Package

--- a/.github/workflows/Hackney.Core.Validation.yml
+++ b/.github/workflows/Hackney.Core.Validation.yml
@@ -12,8 +12,6 @@ jobs:
   calculate-version:
     name: Calculate Version
     runs-on: ubuntu-latest
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -38,8 +36,6 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Hackney.Shared.Strings.yml
+++ b/.github/workflows/Hackney.Shared.Strings.yml
@@ -60,7 +60,7 @@ jobs:
       # - name: Checkout
         # uses: actions/checkout@v2
       # - name: Build
-        # run: docker-compose build hackney-shared-strings      
+        # run: docker compose build hackney-shared-strings      
 
   publish-package:
     name: Publish Package

--- a/.github/workflows/Hackney.Shared.Strings.yml
+++ b/.github/workflows/Hackney.Shared.Strings.yml
@@ -12,8 +12,6 @@ jobs:
   calculate-version:
     name: Calculate Version
     runs-on: ubuntu-latest
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -38,8 +36,6 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/Hackney.Shared.Strings.yml
+++ b/.github/workflows/Hackney.Shared.Strings.yml
@@ -13,7 +13,7 @@ jobs:
     name: Calculate Version
     runs-on: ubuntu-latest
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     outputs:
       version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
     steps:
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: calculate-version
     env:
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
     # runs-on: ubuntu-latest
     # needs: calculate-version
     # env:
-      # LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      # LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     # outputs:
       # version: ${{ needs.calculate-version.outputs.version }}
     # steps:
@@ -72,7 +72,7 @@ jobs:
     needs: calculate-version
     env:
       VERSION: ${{ needs.calculate-version.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.LBHPACKAGESTOKEN }}
+      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -83,4 +83,4 @@ jobs:
       - name: Publish the Package
         run: |
           cd Hackney.Shared/Hackney.Shared.Strings/bin/Release
-          dotnet nuget push Hackney.Shared.Strings.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.NUGET_KEY }}
+          dotnet nuget push Hackney.Shared.Strings.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}

--- a/Hackney.Core.Tests/Hackney.Core.Tests.Authorization/Dockerfile
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.Authorization/Dockerfile
@@ -3,8 +3,6 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
 
-ARG LBHPACKAGESTOKEN
-ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -13,9 +11,17 @@ COPY ./Hackney.Core.Tests/Hackney.Core.Tests.Authorization/Hackney.Core.Tests.Au
 COPY ./Hackney.Core/Hackney.Core.JWT/Hackney.Core.JWT.csproj ./Hackney.Core/Hackney.Core.JWT/
 COPY /nuget.config /root/.nuget/NuGet/NuGet.Config
 
-RUN dotnet restore ./Hackney.Core/Hackney.Core.JWT/Hackney.Core.JWT.csproj
-RUN dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.Authorization/Hackney.Core.Tests.Authorization.csproj
-RUN dotnet restore ./Hackney.Core/Hackney.Core.Authorization/Hackney.Core.Authorization.csproj
+# We mount secrets so they can't end up in logs or build layers.
+# We chain both restore commands so we only make the token available
+# once and don't store it elsewhere.
+# see:
+#   - https://docs.docker.com/reference/dockerfile/#arg
+#   - https://docs.docker.com/compose/how-tos/use-secrets/ 
+RUN --mount=type=secret,id=LBHPACKAGESTOKEN \
+  export LBHPACKAGESTOKEN=$(cat /run/secrets/LBHPACKAGESTOKEN) && \
+  dotnet restore ./Hackney.Core/Hackney.Core.JWT/Hackney.Core.JWT.csproj && \
+  dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.Authorization/Hackney.Core.Tests.Authorization.csproj && \
+  dotnet restore ./Hackney.Core/Hackney.Core.Authorization/Hackney.Core.Authorization.csproj
 
 # Copy everything else and build
 COPY . .

--- a/Hackney.Core.Tests/Hackney.Core.Tests.DynamoDb/Dockerfile
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.DynamoDb/Dockerfile
@@ -3,8 +3,6 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
 
-ARG LBHPACKAGESTOKEN
-ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -13,9 +11,17 @@ COPY ./Hackney.Core.Tests/Hackney.Core.Tests.DynamoDb/Hackney.Core.Tests.DynamoD
 COPY ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/
 COPY /nuget.config /root/.nuget/NuGet/NuGet.Config
 
-RUN dotnet restore ./Hackney.Core/Hackney.Core.DynamoDb/Hackney.Core.DynamoDb.csproj
-RUN dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.DynamoDb/Hackney.Core.Tests.DynamoDb.csproj
-RUN dotnet restore ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj
+# We mount secrets so they can't end up in logs or build layers.
+# We chain both restore commands so we only make the token available
+# once and don't store it elsewhere.
+# see:
+#   - https://docs.docker.com/reference/dockerfile/#arg
+#   - https://docs.docker.com/compose/how-tos/use-secrets/ 
+RUN --mount=type=secret,id=LBHPACKAGESTOKEN \
+  export LBHPACKAGESTOKEN=$(cat /run/secrets/LBHPACKAGESTOKEN) && \
+  dotnet restore ./Hackney.Core/Hackney.Core.DynamoDb/Hackney.Core.DynamoDb.csproj && \
+  dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.DynamoDb/Hackney.Core.Tests.DynamoDb.csproj && \
+  dotnet restore ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj
 
 # Copy everything else and build
 COPY . .

--- a/Hackney.Core.Tests/Hackney.Core.Tests.ElasticSearch/Dockerfile
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.ElasticSearch/Dockerfile
@@ -3,8 +3,6 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
 
-ARG LBHPACKAGESTOKEN
-ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -13,9 +11,17 @@ COPY ./Hackney.Core.Tests/Hackney.Core.Tests.ElasticSearch/Hackney.Core.Tests.El
 COPY ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/
 COPY /nuget.config /root/.nuget/NuGet/NuGet.Config
 
-RUN dotnet restore ./Hackney.Core/Hackney.Core.ElasticSearch/Hackney.Core.ElasticSearch.csproj
-RUN dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.ElasticSearch/Hackney.Core.Tests.ElasticSearch.csproj
-RUN dotnet restore ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj
+# We mount secrets so they can't end up in logs or build layers.
+# We chain both restore commands so we only make the token available
+# once and don't store it elsewhere.
+# see:
+#   - https://docs.docker.com/reference/dockerfile/#arg
+#   - https://docs.docker.com/compose/how-tos/use-secrets/ 
+RUN --mount=type=secret,id=LBHPACKAGESTOKEN \
+  export LBHPACKAGESTOKEN=$(cat /run/secrets/LBHPACKAGESTOKEN) && \
+  dotnet restore ./Hackney.Core/Hackney.Core.ElasticSearch/Hackney.Core.ElasticSearch.csproj && \
+  dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.ElasticSearch/Hackney.Core.Tests.ElasticSearch.csproj && \
+  dotnet restore ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj
 
 # Copy everything else and build
 COPY . .

--- a/Hackney.Core.Tests/Hackney.Core.Tests.Enums/Dockerfile
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.Enums/Dockerfile
@@ -3,8 +3,6 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 # disable microsoft telemetry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
 
-ARG LBHPACKAGESTOKEN
-ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
 WORKDIR /app
 
 WORKDIR /app
@@ -15,8 +13,16 @@ COPY ./Hackney.Core/Hackney.Core.Enums/Hackney.Core.Enums.csproj ./Hackney.Core/
 COPY ./Hackney.Core.Tests/Hackney.Core.Tests.Enums/Hackney.Core.Tests.Enums.csproj ./Hackney.Core.Tests/Hackney.Core.Tests.Enums/
 COPY /nuget.config /root/.nuget/NuGet/NuGet.Config
 
-RUN dotnet restore ./Hackney.Core/Hackney.Core.Enums/Hackney.Core.Enums.csproj
-RUN dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.Enums/Hackney.Core.Tests.Enums.csproj
+# We mount secrets so they can't end up in logs or build layers.
+# We chain both restore commands so we only make the token available
+# once and don't store it elsewhere.
+# see:
+#   - https://docs.docker.com/reference/dockerfile/#arg
+#   - https://docs.docker.com/compose/how-tos/use-secrets/ 
+RUN --mount=type=secret,id=LBHPACKAGESTOKEN \
+  export LBHPACKAGESTOKEN=$(cat /run/secrets/LBHPACKAGESTOKEN) && \
+  dotnet restore ./Hackney.Core/Hackney.Core.Enums/Hackney.Core.Enums.csproj && \
+  dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.Enums/Hackney.Core.Tests.Enums.csproj
 
 # Copy everything else and build
 COPY . .

--- a/Hackney.Core.Tests/Hackney.Core.Tests.HealthCheck/Dockerfile
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.HealthCheck/Dockerfile
@@ -3,8 +3,6 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
 
-ARG LBHPACKAGESTOKEN
-ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -13,9 +11,17 @@ COPY ./Hackney.Core.Tests/Hackney.Core.Tests.HealthCheck/Hackney.Core.Tests.Heal
 COPY ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/
 COPY /nuget.config /root/.nuget/NuGet/NuGet.Config
 
-RUN dotnet restore ./Hackney.Core/Hackney.Core.HealthCheck/Hackney.Core.HealthCheck.csproj
-RUN dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.HealthCheck/Hackney.Core.Tests.HealthCheck.csproj
-RUN dotnet restore ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj
+# We mount secrets so they can't end up in logs or build layers.
+# We chain both restore commands so we only make the token available
+# once and don't store it elsewhere.
+# see:
+#   - https://docs.docker.com/reference/dockerfile/#arg
+#   - https://docs.docker.com/compose/how-tos/use-secrets/ 
+RUN --mount=type=secret,id=LBHPACKAGESTOKEN \
+  export LBHPACKAGESTOKEN=$(cat /run/secrets/LBHPACKAGESTOKEN) && \
+  dotnet restore ./Hackney.Core/Hackney.Core.HealthCheck/Hackney.Core.HealthCheck.csproj && \
+  dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.HealthCheck/Hackney.Core.Tests.HealthCheck.csproj && \
+  dotnet restore ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj
 
 # Copy everything else and build
 COPY . .

--- a/Hackney.Core.Tests/Hackney.Core.Tests.Http/Dockerfile
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.Http/Dockerfile
@@ -3,8 +3,6 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
 
-ARG LBHPACKAGESTOKEN
-ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -13,9 +11,17 @@ COPY ./Hackney.Core.Tests/Hackney.Core.Tests.Http/Hackney.Core.Tests.Http.csproj
 COPY ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/
 COPY /nuget.config /root/.nuget/NuGet/NuGet.Config
 
-RUN dotnet restore ./Hackney.Core/Hackney.Core.Http/Hackney.Core.Http.csproj
-RUN dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.Http/Hackney.Core.Tests.Http.csproj
-RUN dotnet restore ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj
+# We mount secrets so they can't end up in logs or build layers.
+# We chain both restore commands so we only make the token available
+# once and don't store it elsewhere.
+# see:
+#   - https://docs.docker.com/reference/dockerfile/#arg
+#   - https://docs.docker.com/compose/how-tos/use-secrets/ 
+RUN --mount=type=secret,id=LBHPACKAGESTOKEN \
+  export LBHPACKAGESTOKEN=$(cat /run/secrets/LBHPACKAGESTOKEN) && \
+  dotnet restore ./Hackney.Core/Hackney.Core.Http/Hackney.Core.Http.csproj && \
+  dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.Http/Hackney.Core.Tests.Http.csproj && \
+  dotnet restore ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj
 
 # Copy everything else and build
 COPY . .

--- a/Hackney.Core.Tests/Hackney.Core.Tests.JWT/Dockerfile
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.JWT/Dockerfile
@@ -3,8 +3,6 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
 
-ARG LBHPACKAGESTOKEN
-ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -13,9 +11,17 @@ COPY ./Hackney.Core.Tests/Hackney.Core.Tests.JWT/Hackney.Core.Tests.JWT.csproj .
 COPY ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/
 COPY /nuget.config /root/.nuget/NuGet/NuGet.Config
 
-RUN dotnet restore ./Hackney.Core/Hackney.Core.JWT/Hackney.Core.JWT.csproj
-RUN dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.JWT/Hackney.Core.Tests.JWT.csproj
-RUN dotnet restore ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj
+# We mount secrets so they can't end up in logs or build layers.
+# We chain both restore commands so we only make the token available
+# once and don't store it elsewhere.
+# see:
+#   - https://docs.docker.com/reference/dockerfile/#arg
+#   - https://docs.docker.com/compose/how-tos/use-secrets/ 
+RUN --mount=type=secret,id=LBHPACKAGESTOKEN \
+  export LBHPACKAGESTOKEN=$(cat /run/secrets/LBHPACKAGESTOKEN) && \
+  dotnet restore ./Hackney.Core/Hackney.Core.JWT/Hackney.Core.JWT.csproj && \
+  dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.JWT/Hackney.Core.Tests.JWT.csproj && \
+  dotnet restore ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj
 
 # Copy everything else and build
 COPY . .

--- a/Hackney.Core.Tests/Hackney.Core.Tests.Logging/Dockerfile
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.Logging/Dockerfile
@@ -3,8 +3,6 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
 
-ARG LBHPACKAGESTOKEN
-ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -13,9 +11,17 @@ COPY ./Hackney.Core.Tests/Hackney.Core.Tests.Logging/Hackney.Core.Tests.Logging.
 COPY ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/
 COPY /nuget.config /root/.nuget/NuGet/NuGet.Config
 
-RUN dotnet restore ./Hackney.Core/Hackney.Core.Logging/Hackney.Core.Logging.csproj
-RUN dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.Logging/Hackney.Core.Tests.Logging.csproj
-RUN dotnet restore ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj
+# We mount secrets so they can't end up in logs or build layers.
+# We chain both restore commands so we only make the token available
+# once and don't store it elsewhere.
+# see:
+#   - https://docs.docker.com/reference/dockerfile/#arg
+#   - https://docs.docker.com/compose/how-tos/use-secrets/ 
+RUN --mount=type=secret,id=LBHPACKAGESTOKEN \
+  export LBHPACKAGESTOKEN=$(cat /run/secrets/LBHPACKAGESTOKEN) && \
+  dotnet restore ./Hackney.Core/Hackney.Core.Logging/Hackney.Core.Logging.csproj && \
+  dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.Logging/Hackney.Core.Tests.Logging.csproj && \
+  dotnet restore ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj
 
 # Copy everything else and build
 COPY . .

--- a/Hackney.Core.Tests/Hackney.Core.Tests.Middleware/Dockerfile
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.Middleware/Dockerfile
@@ -20,8 +20,8 @@ COPY /nuget.config /root/.nuget/NuGet/NuGet.Config
 #   - https://docs.docker.com/compose/how-tos/use-secrets/ 
 RUN --mount=type=secret,id=LBHPACKAGESTOKEN \
   export LBHPACKAGESTOKEN=$(cat /run/secrets/LBHPACKAGESTOKEN) && \
-  dotnet restore ./Hackney.Core/Hackney.Core.Middleware/Hackney.Core.Middleware.csproj) && \
-  dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.Middleware/Hackney.Core.Tests.Middleware.csproj) && \
+  dotnet restore ./Hackney.Core/Hackney.Core.Middleware/Hackney.Core.Middleware.csproj && \
+  dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.Middleware/Hackney.Core.Tests.Middleware.csproj && \
   dotnet restore ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj
 
 # Copy everything else and build

--- a/Hackney.Core.Tests/Hackney.Core.Tests.Middleware/Dockerfile
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.Middleware/Dockerfile
@@ -3,11 +3,6 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
 
-ARG LBHPACKAGESTOKEN
-ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
-
-ARG LBHPACKAGESTOKEN
-ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -17,9 +12,17 @@ COPY ./Hackney.Core.Tests/Hackney.Core.Tests.Middleware/Hackney.Core.Tests.Middl
 COPY ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/
 COPY /nuget.config /root/.nuget/NuGet/NuGet.Config
 
-RUN dotnet restore ./Hackney.Core/Hackney.Core.Middleware/Hackney.Core.Middleware.csproj
-RUN dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.Middleware/Hackney.Core.Tests.Middleware.csproj
-RUN dotnet restore ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj
+# We mount secrets so they can't end up in logs or build layers.
+# We chain both restore commands so we only make the token available
+# once and don't store it elsewhere.
+# see:
+#   - https://docs.docker.com/reference/dockerfile/#arg
+#   - https://docs.docker.com/compose/how-tos/use-secrets/ 
+RUN --mount=type=secret,id=LBHPACKAGESTOKEN \
+  export LBHPACKAGESTOKEN=$(cat /run/secrets/LBHPACKAGESTOKEN) && \
+  dotnet restore ./Hackney.Core/Hackney.Core.Middleware/Hackney.Core.Middleware.csproj) && \
+  dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.Middleware/Hackney.Core.Tests.Middleware.csproj) && \
+  dotnet restore ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj
 
 # Copy everything else and build
 COPY . .

--- a/Hackney.Core.Tests/Hackney.Core.Tests.Sns/Dockerfile
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.Sns/Dockerfile
@@ -3,8 +3,6 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
 
-ARG LBHPACKAGESTOKEN
-ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -13,9 +11,17 @@ COPY ./Hackney.Core.Tests/Hackney.Core.Tests.Sns/Hackney.Core.Tests.Sns.csproj .
 COPY ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/
 COPY /nuget.config /root/.nuget/NuGet/NuGet.Config
 
-RUN dotnet restore ./Hackney.Core/Hackney.Core.Sns/Hackney.Core.Sns.csproj
-RUN dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.Sns/Hackney.Core.Tests.Sns.csproj
-RUN dotnet restore ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj
+# We mount secrets so they can't end up in logs or build layers.
+# We chain both restore commands so we only make the token available
+# once and don't store it elsewhere.
+# see:
+#   - https://docs.docker.com/reference/dockerfile/#arg
+#   - https://docs.docker.com/compose/how-tos/use-secrets/ 
+RUN --mount=type=secret,id=LBHPACKAGESTOKEN \
+  export LBHPACKAGESTOKEN=$(cat /run/secrets/LBHPACKAGESTOKEN) && \
+  dotnet restore ./Hackney.Core/Hackney.Core.Sns/Hackney.Core.Sns.csproj && \
+  dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.Sns/Hackney.Core.Tests.Sns.csproj && \
+  dotnet restore ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj
 
 # Copy everything else and build
 COPY . .

--- a/Hackney.Core.Tests/Hackney.Core.Tests.Validation.AspNet/Dockerfile
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.Validation.AspNet/Dockerfile
@@ -3,8 +3,6 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
 
-ARG LBHPACKAGESTOKEN
-ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -13,9 +11,17 @@ COPY ./Hackney.Core.Tests/Hackney.Core.Tests.Validation.AspNet/Hackney.Core.Test
 COPY ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/
 COPY /nuget.config /root/.nuget/NuGet/NuGet.Config
 
-RUN dotnet restore ./Hackney.Core/Hackney.Core.Validation.AspNet/Hackney.Core.Validation.AspNet.csproj
-RUN dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.Validation.AspNet/Hackney.Core.Tests.Validation.AspNet.csproj
-RUN dotnet restore ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj
+# We mount secrets so they can't end up in logs or build layers.
+# We chain both restore commands so we only make the token available
+# once and don't store it elsewhere.
+# see:
+#   - https://docs.docker.com/reference/dockerfile/#arg
+#   - https://docs.docker.com/compose/how-tos/use-secrets/ 
+RUN --mount=type=secret,id=LBHPACKAGESTOKEN \
+  export LBHPACKAGESTOKEN=$(cat /run/secrets/LBHPACKAGESTOKEN) && \
+  dotnet restore ./Hackney.Core/Hackney.Core.Validation.AspNet/Hackney.Core.Validation.AspNet.csproj && \
+  dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.Validation.AspNet/Hackney.Core.Tests.Validation.AspNet.csproj && \
+  dotnet restore ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj
 
 # Copy everything else and build
 COPY . .

--- a/Hackney.Core.Tests/Hackney.Core.Tests.Validation/Dockerfile
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.Validation/Dockerfile
@@ -3,8 +3,6 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
 
-ARG LBHPACKAGESTOKEN
-ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -13,9 +11,17 @@ COPY ./Hackney.Core.Tests/Hackney.Core.Tests.Validation/Hackney.Core.Tests.Valid
 COPY ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/
 COPY /nuget.config /root/.nuget/NuGet/NuGet.Config
 
-RUN dotnet restore ./Hackney.Core/Hackney.Core.Validation/Hackney.Core.Validation.csproj
-RUN dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.Validation/Hackney.Core.Tests.Validation.csproj
-RUN dotnet restore ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj
+# We mount secrets so they can't end up in logs or build layers.
+# We chain both restore commands so we only make the token available
+# once and don't store it elsewhere.
+# see:
+#   - https://docs.docker.com/reference/dockerfile/#arg
+#   - https://docs.docker.com/compose/how-tos/use-secrets/ 
+RUN --mount=type=secret,id=LBHPACKAGESTOKEN \
+  export LBHPACKAGESTOKEN=$(cat /run/secrets/LBHPACKAGESTOKEN) && \
+  dotnet restore ./Hackney.Core/Hackney.Core.Validation/Hackney.Core.Validation.csproj && \
+  dotnet restore ./Hackney.Core.Tests/Hackney.Core.Tests.Validation/Hackney.Core.Tests.Validation.csproj && \
+  dotnet restore ./Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/Hackney.Core.Testing.Shared.csproj
 
 # Copy everything else and build
 COPY . .

--- a/Hackney.Core/Hackney.Core.Authorization/Dockerfile
+++ b/Hackney.Core/Hackney.Core.Authorization/Dockerfile
@@ -3,15 +3,21 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
 
-ARG LBHPACKAGESTOKEN
-ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
 COPY ./Hackney.Core/Hackney.Core.Authorization/Hackney.Core.Authorization.csproj ./Hackney.Core/Hackney.Core.Authorization/
 COPY /nuget.config /root/.nuget/NuGet/NuGet.Config
 
-RUN dotnet restore ./Hackney.Core/Hackney.Core.Authorization/Hackney.Core.Authorization.csproj
+# We mount secrets so they can't end up in logs or build layers.
+# We chain both restore commands so we only make the token available
+# once and don't store it elsewhere.
+# see:
+#   - https://docs.docker.com/reference/dockerfile/#arg
+#   - https://docs.docker.com/compose/how-tos/use-secrets/ 
+RUN --mount=type=secret,id=LBHPACKAGESTOKEN \
+  export LBHPACKAGESTOKEN=$(cat /run/secrets/LBHPACKAGESTOKEN) && \
+  dotnet restore ./Hackney.Core/Hackney.Core.Authorization/Hackney.Core.Authorization.csproj
 
 # Copy everything else and build
 COPY . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,95 +7,100 @@ services:
     build:
       context: .
       dockerfile: Hackney.Core.Tests/Hackney.Core.Tests.Authorization/Dockerfile
-      args:
-        - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}
+      secrets:
+        - LBHPACKAGESTOKEN
 
   hackney-core-dynamodb-test:
     image: hackney-core-dynamodb-test
     build:
       context: .
       dockerfile: Hackney.Core.Tests/Hackney.Core.Tests.DynamoDb/Dockerfile
-      args:
-        - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}
+      secrets:
+        - LBHPACKAGESTOKEN
 
   hackney-core-elasticsearch-test:
     image: hackney-core-elasticsearch-test
     build:
       context: .
       dockerfile: Hackney.Core.Tests/Hackney.Core.Tests.ElasticSearch/Dockerfile
-      args:
-        - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}
+      secrets:
+        - LBHPACKAGESTOKEN
 
   hackney-core-enums-test:
     image: hackney-core-enums-test
     build:
       context: .
       dockerfile: Hackney.Core.Tests/Hackney.Core.Tests.Enums/Dockerfile
-      args:
-        - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}
+      secrets:
+        - LBHPACKAGESTOKEN
 
   hackney-core-healthcheck-test:
     image: hackney-core-healthcheck-test
     build:
       context: .
       dockerfile: Hackney.Core.Tests/Hackney.Core.Tests.HealthCheck/Dockerfile
-      args:
-        - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}
+      secrets:
+        - LBHPACKAGESTOKEN
         
   hackney-core-http-test:
     image: hackney-core-http-test
     build:
       context: .
       dockerfile: Hackney.Core.Tests/Hackney.Core.Tests.Http/Dockerfile
-      args:
-        - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}
+      secrets:
+        - LBHPACKAGESTOKEN
 
   hackney-core-jwt-test:
     image: hackney-core-jwt-test
     build:
       context: .
       dockerfile: Hackney.Core.Tests/Hackney.Core.Tests.JWT/Dockerfile
-      args:
-        - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}
-  
+      secrets:
+        - LBHPACKAGESTOKEN
+
   hackney-core-logging-test:
     image: hackney-core-logging-test
     build:
       context: .
       dockerfile: Hackney.Core.Tests/Hackney.Core.Tests.Logging/Dockerfile
-      args:
-        - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}
+      secrets:
+        - LBHPACKAGESTOKEN
   
   hackney-core-middleware-test:
     image: hackney-core-middleware-test
     build:
       context: .
       dockerfile: Hackney.Core.Tests/Hackney.Core.Tests.Middleware/Dockerfile
-      args:
-        - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}
-      
+      secrets:
+        - LBHPACKAGESTOKEN
+
   hackney-core-sns-test:
     image: hackney-core-sns-test
     build:
       context: .
       dockerfile: Hackney.Core.Tests/Hackney.Core.Tests.Sns/Dockerfile
-      args:
-        - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}
-  
+      secrets:
+        - LBHPACKAGESTOKEN
+
   hackney-core-validation-test:
     image: hackney-core-validation-test
     build:
       context: .
       dockerfile: Hackney.Core.Tests/Hackney.Core.Tests.Validation/Dockerfile
-      args:
-        - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}
-  
+      secrets:
+        - LBHPACKAGESTOKEN
 
   hackney-core-validation-aspnet-test:
     image: hackney-core-validation-aspnet-test
     build:
       context: .
       dockerfile: Hackney.Core.Tests/Hackney.Core.Tests.Validation.AspNet/Dockerfile
-      args:
-        - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}
-      
+      secrets:
+        - LBHPACKAGESTOKEN
+
+# see https://docs.docker.com/compose/how-tos/use-secrets/#build-secrets
+# Combines with a "secrets" block in each service to expose it as a file in
+# /run/secrets/, e.g. /run/secrets/LBHPACKAGESTOKEN
+secrets:
+  LBHPACKAGESTOKEN:
+    environment: LBHPACKAGESTOKEN


### PR DESCRIPTION
This change removes two environment variables from CI which have been used to carry credentials to publish/read packages to our GitHub Packages NuGet registry:

- `LBHPACKAGESTOKEN`
- `NUGET_KEY`

`LBHPACKAGESTOKEN` continues to be used for local development.

What is the problem we're trying to solve?

Historically we've published packages from our local machines, which requires a token to authenticate with the GitHub Packages NuGet Registry. Now we use CI to publish packages there is a GitHub-managed token we can use instead..

> If you're using a registry that supports granular permissions, and your workflow is using a personal access token to authenticate to the registry, then we highly recommend you update your workflow to use the GITHUB_TOKEN.
>  ~ from https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#authenticating-to-package-registries-with-granular-permissions

This change removes both `LBHPACKAGESTOKEN` and `NUGET_KEY` tokens from the GitHub Actions workflow, replacing them where needed with the managed `GITHUB_TOKEN` token that's automatically made available to all jobs.

In order to keep the local development/management experience the same, references to `LBHPACKAGESTOKEN` have been kept as-is in the Docker and Docker Compose setup.

Docker's documentation [suggests](https://docs.docker.com/reference/dockerfile/#arg) not to use build arguments to pass secrets, so this change updates the `Dockerfile` to use [secret mounts](https://docs.docker.com/build/building/secrets/#secret-mounts), and the recommended way to [manage secrets in docker compose](https://docs.docker.com/compose/how-tos/use-secrets/).

This will allow us to remove the shared secrets in GitHub Actions:

- `NUGET_KEY`
- `LBHPACKAGESTOKEN`

At the same time, this doesn't affect the local development workflow.n. e.g Addition of test database setup, addition of first test and production class, removal of buggy code, etc.

Docker's documentation [suggests](https://docs.docker.com/reference/dockerfile/#arg) not to use build arguments to pass secrets, so this PR also updates the `Dockerfile` to use [secret mounts](https://docs.docker.com/build/building/secrets/#secret-mounts), and the recommended way to [manage secrets in docker compose](https://docs.docker.com/compose/how-tos/use-secrets/).

#### How to review this change

There are quite a few lines changed here. I've split them into separate commits to make review easier :).

#### _Checklist_

- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

- [ ] Remove lbh-core from the shared secrets listed above in GitHub Actions
