### PR TITLE
Ignore ConditionalCheckFailedException during entity deletion in DynamoDbFixture

### DIFF
--- a/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.DynamoDb/DynamoDbFixture.cs
+++ b/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.DynamoDb/DynamoDbFixture.cs
@@ -120,6 +120,7 @@ namespace Hackney.Core.Testing.DynamoDb
                 }
                 catch (ConditionalCheckFailedException ex)
                 {
+                    // Ignore this exception as it means the entity has already been deleted
                     Console.WriteLine($"Delete failed: {ex.Message}");
                 }
             });

--- a/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.DynamoDb/DynamoDbFixture.cs
+++ b/Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.DynamoDb/DynamoDbFixture.cs
@@ -112,7 +112,17 @@ namespace Hackney.Core.Testing.DynamoDb
         public async Task SaveEntityAsync<T>(T entity) where T : class
         {
             await DynamoDbContext.SaveAsync<T>(entity).ConfigureAwait(false);
-            _cleanup.Add(async () => await DynamoDbContext.DeleteAsync(entity).ConfigureAwait(false));
+            _cleanup.Add(async () =>
+            {
+                try
+                {
+                    await DynamoDbContext.DeleteAsync(entity).ConfigureAwait(false);
+                }
+                catch (ConditionalCheckFailedException ex)
+                {
+                    Console.WriteLine($"Delete failed: {ex.Message}");
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
Occasionally our tests fail in pipelines with the only error message being "conditional request failed". It's also difficult to recreate these test failures locally, making it frustrating to debug.

After some digging, this error message happens when the test fixture attempts to delete a db entity twice. This could happen because of asynchronous tests or other reasons. A simple fix is to log that this error happens without throwing an error and consequently failing the tests. This seems to work.