### PR TITLE
Add cognito authentication flow token schema support.

### DIFF
--- a/Hackney.Core.Tests/Hackney.Core.Tests.JWT/Hackney.Core.Tests.JWT.csproj
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.JWT/Hackney.Core.Tests.JWT.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
-	  <NoWarn>CA1303;CA1305;CA1001;CA1062;CA1307</NoWarn>
+	  <NoWarn>CA1303;CA1305;CA1001;CA1062;CA1307;CA1707</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Hackney.Core.Tests/Hackney.Core.Tests.JWT/Hackney.Core.Tests.JWT.csproj
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.JWT/Hackney.Core.Tests.JWT.csproj
@@ -21,6 +21,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/Hackney.Core.Tests/Hackney.Core.Tests.JWT/Hackney.Core.Tests.JWT.csproj
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.JWT/Hackney.Core.Tests.JWT.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/Hackney.Core.Tests/Hackney.Core.Tests.JWT/Hackney.Core.Tests.JWT.csproj
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.JWT/Hackney.Core.Tests.JWT.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
 	  <NoWarn>CA1303;CA1305;CA1001;CA1062;CA1307;CA1707</NoWarn>
   </PropertyGroup>

--- a/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenFactoryTests.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenFactoryTests.cs
@@ -3,6 +3,7 @@ using Hackney.Core.JWT;
 using Microsoft.AspNetCore.Http;
 using Moq;
 using System;
+using System.Linq;
 using Xunit;
 
 namespace Hackney.Core.Tests.JWT
@@ -10,6 +11,7 @@ namespace Hackney.Core.Tests.JWT
     public class TokenFactoryTests
     {
         private readonly Mock<IHeaderDictionary> _mockHeaders;
+        // I've checked it - this is a dummy token.
         private readonly string _tokenString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMTUwMTgxMTYwOTIwOTg2NzYxMTMiLCJlbWFpbCI6ImUyZS10ZXN0aW5nQGRldmVsb3BtZW50LmNvbSIsImlzcyI6IkhhY2tuZXkiLCJuYW1lIjoiVGVzdGVyIiwiZ3JvdXBzIjpbImUyZS10ZXN0aW5nIl0sImlhdCI6MTYyMzA1ODIzMn0.SooWAr-NUZLwW8brgiGpi2jZdWjyZBwp4GJikn0PvEw";
 
         private readonly TokenFactory _sut;
@@ -60,6 +62,30 @@ namespace Hackney.Core.Tests.JWT
             token.Name.Should().Be("Tester");
             token.Nbf.Should().Be(0);
             token.Sub.Should().Be("115018116092098676113");
+        }
+
+        [Fact]
+        public void TokenFactory_CreateMethod_MapsTheCognitoTokenCorrectly()
+        {
+            // arrange
+            var headerName = "Authorization";
+            var testToken = TokenTestsHelper.GenerateTestTokenPresentationJWT(TokenSchema.Cognito);
+            var expectedGroupsArray = testToken.TokenObj.CustomGroups.Split(TokenTestsHelper.CognitoTokenGoogleGroupsSeparator).ToArray();
+
+            _mockHeaders.Reset();
+            _mockHeaders.Setup(x => x[headerName]).Returns(testToken.JwtString);
+
+            // act 
+            var decodedToken = _sut.Create(headerDictionary: _mockHeaders.Object, headerName);
+
+            // assert
+            decodedToken.Email.Should().Be(testToken.TokenObj.Email);
+            decodedToken.Exp.Should().Be(testToken.TokenObj.Exp);
+            decodedToken.Groups.Should().BeEquivalentTo(expectedGroupsArray);
+            decodedToken.Iat.Should().Be(testToken.TokenObj.Iat);
+            decodedToken.Name.Should().Be(testToken.TokenObj.Name);
+            decodedToken.Nbf.Should().Be(testToken.TokenObj.Nbf);
+            decodedToken.Sub.Should().Be(testToken.TokenObj.Sub);
         }
     }
 }

--- a/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenFactoryTests.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenFactoryTests.cs
@@ -51,17 +51,24 @@ namespace Hackney.Core.Tests.JWT
         [InlineData("some-header")]
         public void TokenFactoryCreateTestReturnsToken(string headerName)
         {
+            // arrange
+            var testToken = TokenTestsHelper.GenerateTestTokenPresentationJWT(TokenSchema.Old);
             var actualHeader = headerName ?? ITokenFactory.DefaultHeaderName;
-            _mockHeaders.Setup(x => x[actualHeader]).Returns(_tokenString);
 
-            var token = _sut.Create(_mockHeaders.Object);
-            token.Email.Should().Be("e2e-testing@development.com");
-            token.Exp.Should().Be(0);
-            token.Groups.Should().BeEquivalentTo(new[] { "e2e-testing" });
-            token.Iat.Should().Be(1623058232);
-            token.Name.Should().Be("Tester");
-            token.Nbf.Should().Be(0);
-            token.Sub.Should().Be("115018116092098676113");
+            _mockHeaders.Reset();
+            _mockHeaders.Setup(x => x[actualHeader]).Returns(testToken.JwtString);
+
+            // act 
+            var decodedToken = _sut.Create(_mockHeaders.Object, actualHeader);
+
+            // assert
+            decodedToken.Email.Should().Be(testToken.TokenObj.Email);
+            decodedToken.Exp.Should().Be(testToken.TokenObj.Exp);
+            decodedToken.Groups.Should().BeEquivalentTo(testToken.TokenObj.Groups);
+            decodedToken.Iat.Should().Be(testToken.TokenObj.Iat);
+            decodedToken.Name.Should().Be(testToken.TokenObj.Name);
+            decodedToken.Nbf.Should().Be(testToken.TokenObj.Nbf);
+            decodedToken.Sub.Should().Be(testToken.TokenObj.Sub);
         }
 
         [Fact]
@@ -70,7 +77,7 @@ namespace Hackney.Core.Tests.JWT
             // arrange
             var headerName = "Authorization";
             var testToken = TokenTestsHelper.GenerateTestTokenPresentationJWT(TokenSchema.Cognito);
-            var expectedGroupsArray = testToken.TokenObj.CustomGroups.Split(TokenTestsHelper.CognitoTokenGoogleGroupsSeparator).ToArray();
+            var expectedGroupsArray = testToken.TokenObj.CustomGroups?.Split(TokenTestsHelper.CognitoTokenGoogleGroupsSeparator).ToArray();
 
             _mockHeaders.Reset();
             _mockHeaders.Setup(x => x[headerName]).Returns(testToken.JwtString);

--- a/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenFactoryTests.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenFactoryTests.cs
@@ -94,7 +94,7 @@ namespace Hackney.Core.Tests.JWT
         }
 
         [Fact]
-        public void TokenFactory_CreateMethod_ReturnsEmptyGroupsArrayWhen()
+        public void TokenFactory_CreateMethod_ReturnsEmptyGroupsArrayWhenNeitherGroupsNorCustomGroupsIsSet()
         {
             // arrange
             var headerName = "Authorization";

--- a/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenFactoryTests.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenFactoryTests.cs
@@ -11,15 +11,13 @@ namespace Hackney.Core.Tests.JWT
     public class TokenFactoryTests
     {
         private readonly Mock<IHeaderDictionary> _mockHeaders;
-        // I've checked it - this is a dummy token.
-        private readonly string _tokenString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMTUwMTgxMTYwOTIwOTg2NzYxMTMiLCJlbWFpbCI6ImUyZS10ZXN0aW5nQGRldmVsb3BtZW50LmNvbSIsImlzcyI6IkhhY2tuZXkiLCJuYW1lIjoiVGVzdGVyIiwiZ3JvdXBzIjpbImUyZS10ZXN0aW5nIl0sImlhdCI6MTYyMzA1ODIzMn0.SooWAr-NUZLwW8brgiGpi2jZdWjyZBwp4GJikn0PvEw";
-
         private readonly TokenFactory _sut;
 
         public TokenFactoryTests()
         {
+            var nonEmptyToken = TokenTestsHelper.GenerateTestTokenPresentationJWT(TokenSchema.Old);
             _mockHeaders = new Mock<IHeaderDictionary>();
-            _mockHeaders.Setup(x => x["Authorization"]).Returns(_tokenString);
+            _mockHeaders.Setup(x => x["Authorization"]).Returns(nonEmptyToken.JwtString);
 
             _sut = new TokenFactory();
         }

--- a/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenFactoryTests.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenFactoryTests.cs
@@ -92,5 +92,36 @@ namespace Hackney.Core.Tests.JWT
             decodedToken.Nbf.Should().Be(testToken.TokenObj.Nbf);
             decodedToken.Sub.Should().Be(testToken.TokenObj.Sub);
         }
+
+        [Fact]
+        public void TokenFactory_CreateMethod_ReturnsEmptyGroupsArrayWhen()
+        {
+            // arrange
+            var headerName = "Authorization";
+            var schemaIrrelForTest = TokenSchema.Cognito;
+
+            var grouplessToken = TokenTestsHelper.GenerateTestTokenObj(schemaIrrelForTest);
+            grouplessToken.Groups = null;
+            grouplessToken.CustomGroups = null;
+
+            var grouplessTokenJwtString = TokenTestsHelper.GenerateCleanJwt(grouplessToken, TokenTestsHelper.TestSecret);
+
+            _mockHeaders.Reset();
+            _mockHeaders.Setup(x => x[headerName]).Returns(grouplessTokenJwtString);
+
+            // act 
+            var decodedToken = _sut.Create(headerDictionary: _mockHeaders.Object, headerName);
+
+            // assert
+            // parses fields that exist
+            decodedToken.Email.Should().Be(grouplessToken.Email);
+            decodedToken.Exp.Should().Be(grouplessToken.Exp);
+            decodedToken.Iat.Should().Be(grouplessToken.Iat);
+            decodedToken.Name.Should().Be(grouplessToken.Name);
+            decodedToken.Nbf.Should().Be(grouplessToken.Nbf);
+            decodedToken.Sub.Should().Be(grouplessToken.Sub);
+            // defaults to empty array when no groups are found
+            decodedToken.Groups.Should().BeEquivalentTo(Array.Empty<string>());
+        }
     }
 }

--- a/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenTestsHelper.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenTestsHelper.cs
@@ -96,10 +96,10 @@ namespace Hackney.Core.Tests.JWT
             return handler.WriteToken(securityToken);
         }
 
-        public static TestToken<TokenPresentation> GenerateTestTokenPresentationJWT(TokenSchema tokenSchema)
+        public static TestToken GenerateTestTokenPresentationJWT(TokenSchema tokenSchema)
         {
             var presentationToken = GenerateTestTokenObj(tokenSchema);
-            return new TestToken<TokenPresentation>
+            return new TestToken
             {
                 JwtString = GenerateCleanJwt(presentationToken, TestSecret),
                 TokenObj = presentationToken
@@ -107,10 +107,10 @@ namespace Hackney.Core.Tests.JWT
         }
     }
 
-    internal class TestToken<T> where T : class, new()
+    internal class TestToken where T : class, new()
     {
         public string JwtString { get; set; }
-        public T TokenObj { get; set; }
+        public TokenPresentation TokenObj { get; set; }
     }
 
     internal enum TokenSchema

--- a/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenTestsHelper.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenTestsHelper.cs
@@ -12,7 +12,7 @@ namespace Hackney.Core.Tests.JWT
 {
     internal static class TokenTestsHelper
     {
-        private static string TestSecret => "this-is-a-very-long-test-secret-key-that-is-at-least-32-bytes!";
+        public static string TestSecret => "this-is-a-very-long-test-secret-key-that-is-at-least-32-bytes!";
         public static char CognitoTokenGoogleGroupsSeparator => ';';
         private static Fixture _fixture = new Fixture();
 
@@ -30,7 +30,7 @@ namespace Hackney.Core.Tests.JWT
             return string.Join(CognitoTokenGoogleGroupsSeparator, googleGroups);
         }
 
-        private static TokenPresentation GenerateTestTokenObj(TokenSchema tokenSchema)
+        public static TokenPresentation GenerateTestTokenObj(TokenSchema tokenSchema)
         {
             long now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
             long oneHourFromNow = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds();

--- a/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenTestsHelper.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenTestsHelper.cs
@@ -5,6 +5,7 @@ using AutoFixture;
 using Hackney.Core.JWT;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
+using AutoFixture.Dsl;
 
 namespace Hackney.Core.Tests.JWT
 {
@@ -27,19 +28,24 @@ namespace Hackney.Core.Tests.JWT
             return string.Join(CognitoTokenGoogleGroupsSeparator, googleGroups);
         }
 
-        private static TokenPresentation GenerateTestTokenPresentationObj()
+        private static TokenPresentation GenerateTestTokenObj(TokenSchema tokenSchema)
         {
-            return _fixture.Build<TokenPresentation>()
-                .With(x => x.CustomGroups, GenerateCognitoTokenGroupsString(count: 5))
-                .Create();
+            var builder = _fixture.Build<TokenPresentation>();
+
+            IPostprocessComposer<TokenPresentation> composer;
+
+            if (tokenSchema == TokenSchema.Cognito)
+            {
+                composer = builder.With(t => t.CustomGroups, GenerateCognitoTokenGroupsString(count: 5));
+            }
+            else
+            {
+                composer = builder.With(t => t.Groups, GenerateGoogleGroups(count: 5));
+            }
+
+            return composer.Create();
         }
 
-        private static Token GenerateTestTokenObj()
-        {
-            return _fixture.Build<Token>()
-                .With(x => x.Groups, GenerateGoogleGroups(count: 5))
-                .Create();
-        }
 
         public static string GenerateCleanJwt(TokenPresentation token, string secret)
         {
@@ -76,5 +82,11 @@ namespace Hackney.Core.Tests.JWT
             var securityToken = handler.CreateToken(descriptor);
             return handler.WriteToken(securityToken);
         }
+    }
+
+    internal enum TokenSchema
+    {
+        Old,
+        Cognito
     }
 }

--- a/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenTestsHelper.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenTestsHelper.cs
@@ -1,7 +1,10 @@
 using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using AutoFixture;
 using Hackney.Core.JWT;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
 
 namespace Hackney.Core.Tests.JWT
 {
@@ -36,6 +39,42 @@ namespace Hackney.Core.Tests.JWT
             return _fixture.Build<Token>()
                 .With(x => x.Groups, GenerateGoogleGroups(count: 5))
                 .Create();
+        }
+
+        public static string GenerateCleanJwt(TokenPresentation token, string secret)
+        {
+            var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secret));
+            var credentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
+
+            var claims = new Dictionary<string, object>
+            {
+                { "sub", token.Sub },
+                { "email", token.Email },
+                { "name", token.Name },
+                { "nbf", token.Nbf },
+                { "exp", token.Exp },
+                { "iat", token.Iat }
+            };
+
+            // If old token schema
+            if (token.Groups != null)
+            {
+                claims.Add("groups", token.Groups);
+            }
+            else // If cognito token
+            {
+                claims.Add("custom:groups", token.CustomGroups);
+            }
+
+            var descriptor = new SecurityTokenDescriptor
+            {
+                Claims = claims,
+                SigningCredentials = credentials
+            };
+
+            var handler = new JwtSecurityTokenHandler();
+            var securityToken = handler.CreateToken(descriptor);
+            return handler.WriteToken(securityToken);
         }
     }
 }

--- a/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenTestsHelper.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenTestsHelper.cs
@@ -107,7 +107,7 @@ namespace Hackney.Core.Tests.JWT
         }
     }
 
-    internal class TestToken where T : class, new()
+    internal class TestToken
     {
         public string JwtString { get; set; }
         public TokenPresentation TokenObj { get; set; }

--- a/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenTestsHelper.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenTestsHelper.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Hackney.Core.Tests.JWT
+{
+    internal static class TokenTestsHelper
+    {
+        public static char CognitoTokenGoogleGroupsSeparator => ';';
+
+        private static IEnumerable<string> GenerateGoogleGroups(int count)
+        {
+            if (count < 1) return Enumerable.Empty<string>();
+
+            return Enumerable.Range(1, count).Select(i => $"Google-Group-{i}").ToList();
+        }
+
+        private static string GenerateCognitoTokenGroupsString(int count)
+        {
+            var googleGroups = GenerateGoogleGroups(count);
+
+            return string.Join(CognitoTokenGoogleGroupsSeparator, googleGroups);
+        }
+    }
+}

--- a/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenTestsHelper.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenTestsHelper.cs
@@ -11,6 +11,7 @@ namespace Hackney.Core.Tests.JWT
 {
     internal static class TokenTestsHelper
     {
+        private static string TestSecret => "this-is-a-very-long-test-secret-key-that-is-at-least-32-bytes!";
         public static char CognitoTokenGoogleGroupsSeparator => ';';
         private static Fixture _fixture = new Fixture();
 
@@ -82,6 +83,22 @@ namespace Hackney.Core.Tests.JWT
             var securityToken = handler.CreateToken(descriptor);
             return handler.WriteToken(securityToken);
         }
+
+        public static TestToken<TokenPresentation> GenerateTestTokenPresentationJWT(TokenSchema tokenSchema)
+        {
+            var presentationToken = GenerateTestTokenObj(tokenSchema);
+            return new TestToken<TokenPresentation>
+            {
+                JwtString = GenerateCleanJwt(presentationToken, TestSecret),
+                TokenObj = presentationToken
+            };
+        }
+    }
+
+    internal class TestToken<T> where T : class, new()
+    {
+        public string JwtString { get; set; }
+        public T TokenObj { get; set; }
     }
 
     internal enum TokenSchema

--- a/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenTestsHelper.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenTestsHelper.cs
@@ -51,7 +51,7 @@ namespace Hackney.Core.Tests.JWT
             else
             {
                 composer = composer
-                    .With(t => t.Groups, GenerateGoogleGroups(count: 5))
+                    .With(t => t.Groups, GenerateGoogleGroups(count: 5).ToArray())
                     .With(t => t.CustomGroups, null as string);
             }
 

--- a/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenTestsHelper.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenTestsHelper.cs
@@ -6,6 +6,7 @@ using Hackney.Core.JWT;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using AutoFixture.Dsl;
+using System;
 
 namespace Hackney.Core.Tests.JWT
 {
@@ -31,17 +32,27 @@ namespace Hackney.Core.Tests.JWT
 
         private static TokenPresentation GenerateTestTokenObj(TokenSchema tokenSchema)
         {
+            long now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            long oneHourFromNow = DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds();
+
             var builder = _fixture.Build<TokenPresentation>();
 
-            IPostprocessComposer<TokenPresentation> composer;
+            IPostprocessComposer<TokenPresentation> composer = builder
+                .With(t => t.Iat, now)
+                .With(t => t.Nbf, now)
+                .With(t => t.Exp, oneHourFromNow);
 
             if (tokenSchema == TokenSchema.Cognito)
             {
-                composer = builder.With(t => t.CustomGroups, GenerateCognitoTokenGroupsString(count: 5));
+                composer = composer
+                    .With(t => t.Groups, null as string[])
+                    .With(t => t.CustomGroups, GenerateCognitoTokenGroupsString(count: 5));
             }
             else
             {
-                composer = builder.With(t => t.Groups, GenerateGoogleGroups(count: 5));
+                composer = composer
+                    .With(t => t.Groups, GenerateGoogleGroups(count: 5))
+                    .With(t => t.CustomGroups, null as string);
             }
 
             return composer.Create();
@@ -57,18 +68,14 @@ namespace Hackney.Core.Tests.JWT
             {
                 { "sub", token.Sub },
                 { "email", token.Email },
-                { "name", token.Name },
-                { "nbf", token.Nbf },
-                { "exp", token.Exp },
-                { "iat", token.Iat }
+                { "name", token.Name }
             };
 
-            // If old token schema
             if (token.Groups != null)
             {
                 claims.Add("groups", token.Groups);
             }
-            else // If cognito token
+            else
             {
                 claims.Add("custom:groups", token.CustomGroups);
             }
@@ -76,7 +83,12 @@ namespace Hackney.Core.Tests.JWT
             var descriptor = new SecurityTokenDescriptor
             {
                 Claims = claims,
-                SigningCredentials = credentials
+                SigningCredentials = credentials,
+
+                // converts 'long' unix timestamps to date times
+                Expires = DateTimeOffset.FromUnixTimeSeconds(token.Exp).UtcDateTime,
+                NotBefore = DateTimeOffset.FromUnixTimeSeconds(token.Nbf).UtcDateTime,
+                IssuedAt = DateTimeOffset.FromUnixTimeSeconds(token.Iat).UtcDateTime
             };
 
             var handler = new JwtSecurityTokenHandler();

--- a/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenTestsHelper.cs
+++ b/Hackney.Core.Tests/Hackney.Core.Tests.JWT/TokenTestsHelper.cs
@@ -1,11 +1,14 @@
 using System.Collections.Generic;
 using System.Linq;
+using AutoFixture;
+using Hackney.Core.JWT;
 
 namespace Hackney.Core.Tests.JWT
 {
     internal static class TokenTestsHelper
     {
         public static char CognitoTokenGoogleGroupsSeparator => ';';
+        private static Fixture _fixture = new Fixture();
 
         private static IEnumerable<string> GenerateGoogleGroups(int count)
         {
@@ -19,6 +22,20 @@ namespace Hackney.Core.Tests.JWT
             var googleGroups = GenerateGoogleGroups(count);
 
             return string.Join(CognitoTokenGoogleGroupsSeparator, googleGroups);
+        }
+
+        private static TokenPresentation GenerateTestTokenPresentationObj()
+        {
+            return _fixture.Build<TokenPresentation>()
+                .With(x => x.CustomGroups, GenerateCognitoTokenGroupsString(count: 5))
+                .Create();
+        }
+
+        private static Token GenerateTestTokenObj()
+        {
+            return _fixture.Build<Token>()
+                .With(x => x.Groups, GenerateGoogleGroups(count: 5))
+                .Create();
         }
     }
 }

--- a/Hackney.Core/Hackney.Core.JWT/TokenFactory.cs
+++ b/Hackney.Core/Hackney.Core.JWT/TokenFactory.cs
@@ -12,6 +12,9 @@ namespace Hackney.Core.JWT
     /// </summary>
     public class TokenFactory : ITokenFactory
     {
+        // Separator aws cognito pre-token lambda uses to join Google group names with
+        public char CognitoTokenGoogleGroupsSeparator => ';';
+
         /// <summary>
         /// Extracts a JWT from the supplied Http headers and creates a token object from it.
         /// </summary>
@@ -32,8 +35,42 @@ namespace Hackney.Core.JWT
 
             var handler = new JwtSecurityTokenHandler();
             var jwtToken = handler.ReadJwtToken(encodedString);
+
             var decodedPayload = Base64UrlEncoder.Decode(jwtToken.EncodedPayload);
-            return JsonConvert.DeserializeObject<Token>(decodedPayload);
+
+            // clean architecture principles - separate out presentation concern from domain logic 
+            var presentationToken = JsonConvert.DeserializeObject<TokenPresentation>(decodedPayload);
+
+            if (presentationToken == null)
+                return null;
+
+            // preserve the model that domain logic expects
+            return MapToDomain(presentationToken);
+        }
+
+        private Token MapToDomain(TokenPresentation presentation)
+        {
+            string[] parsedGroups = Array.Empty<string>();
+
+            if (presentation.Groups != null)
+            {
+                parsedGroups = presentation.Groups;
+            }
+            else if (!string.IsNullOrWhiteSpace(presentation.CustomGroups))
+            {
+                parsedGroups = presentation.CustomGroups.Split(this.CognitoTokenGoogleGroupsSeparator, StringSplitOptions.RemoveEmptyEntries);
+            }
+
+            return new Token
+            {
+                Sub = presentation.Sub,
+                Groups = parsedGroups,
+                Email = presentation.Email,
+                Name = presentation.Name,
+                Nbf = presentation.Nbf,
+                Exp = presentation.Exp,
+                Iat = presentation.Iat
+            };
         }
     }
 }

--- a/Hackney.Core/Hackney.Core.JWT/TokenPresentation.cs
+++ b/Hackney.Core/Hackney.Core.JWT/TokenPresentation.cs
@@ -8,7 +8,7 @@ namespace Hackney.Core.JWT
     /// Domain layer contract. Do not use outside Hackney.Core.JWT,
     /// hence 'internal'.
     /// </summary>
-    internal class TokenPresentation
+    public class TokenPresentation
     {
         public string Sub { get; set; }
 

--- a/Hackney.Core/Hackney.Core.JWT/TokenPresentation.cs
+++ b/Hackney.Core/Hackney.Core.JWT/TokenPresentation.cs
@@ -5,8 +5,7 @@ namespace Hackney.Core.JWT
     /// <summary>
     /// Presentation layer object representing what Token could be.
     /// A seperate object is needed to avoid breaking the existing
-    /// Domain layer contract. Do not use outside Hackney.Core.JWT,
-    /// hence 'internal'.
+    /// Domain layer contract. Do not use outside Hackney.Core.JWT
     /// </summary>
     public class TokenPresentation
     {

--- a/Hackney.Core/Hackney.Core.JWT/TokenPresentation.cs
+++ b/Hackney.Core/Hackney.Core.JWT/TokenPresentation.cs
@@ -13,11 +13,11 @@ namespace Hackney.Core.JWT
         public string Sub { get; set; }
 
         // The old token format groups field
-        public string[] Groups { get; set; }
+        public string[]? Groups { get; set; }
 
         // New cognito token format field
         [JsonProperty("custom:groups")]
-        public string CustomGroups { get; set; }
+        public string? CustomGroups { get; set; }
 
         public string Email { get; set; }
         public string Name { get; set; }

--- a/Hackney.Core/Hackney.Core.JWT/TokenPresentation.cs
+++ b/Hackney.Core/Hackney.Core.JWT/TokenPresentation.cs
@@ -1,0 +1,28 @@
+using Newtonsoft.Json;
+
+namespace Hackney.Core.JWT
+{
+    /// <summary>
+    /// Presentation layer object representing what Token could be.
+    /// A seperate object is needed to avoid breaking the existing
+    /// Domain layer contract. Do not use outside Hackney.Core.JWT,
+    /// hence 'internal'.
+    /// </summary>
+    internal class TokenPresentation
+    {
+        public string Sub { get; set; }
+
+        // The old token format groups field
+        public string[] Groups { get; set; }
+
+        // New cognito token format field
+        [JsonProperty("custom:groups")]
+        public string CustomGroups { get; set; }
+
+        public string Email { get; set; }
+        public string Name { get; set; }
+        public long Nbf { get; set; }
+        public long Exp { get; set; }
+        public long Iat { get; set; }
+    }
+}


### PR DESCRIPTION
# What:
 - Decouple the token presentation concern from domain logic.
 - Add conditional token Google `Groups` key construction based on incoming token schema _(groups are either in `Groups` or `CustomGroups`)_.

# Why:
 - Old Hackney authentication flow expects the incoming token to contain Google groups within `Groups` field encoded as `JSON Array`. However, the new schema aims to reduce the size of hackney token _(due to 4kB cookie size limitation)_ by cutting out all the JSON syntax _(which analysis shows increases token size by ~11%)_ and replacing it with `;` separator joined `string`. Additionally, within the new token schema Google groups are stored under `custom:groups` key.

# Notes:
- I've updated the `JWT` tests setup to use generated tokens instead of using the hardcoded one. Done this to prevent having something that looks like real secrets in the code base needlessly alarming developers. Also did this to reduce the git guardian noise. 
- The hardcoded token I removed was a dummy token with values that match hardcoded values within one of the tests I've modified.