### PR TITLE
Update Authorizer package to point to the latest JWT package version that supports Cognito token.

### DIFF
--- a/Hackney.Core/Hackney.Core.Authorization/Hackney.Core.Authorization.csproj
+++ b/Hackney.Core/Hackney.Core.Authorization/Hackney.Core.Authorization.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hackney.Core.JWT" Version="1.87.0-feat-add-cognito0016" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.87.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Hackney.Core/Hackney.Core.Authorization/Hackney.Core.Authorization.csproj
+++ b/Hackney.Core/Hackney.Core.Authorization/Hackney.Core.Authorization.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hackney.Core.JWT" Version="1.72.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.87.0-feat-add-cognito0016" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# What:
 - Bump Hackney.Core.Authorization's Hackney.Core.JWT dependency to latest.

# Why:
 - Ensure Authorization is pointing to the interface from same version of package as is the JWT version used by APIs to pass the actual implementation of referenced interface.

# Notes:
 - Just housekeeping to prevent developers needing to guess what's changes have been missed from JWT the next time they need to bump JWT here. The only real change since 1.72 that JWT received is PR #68 . The other version in between was unintentional deployment triggered by changes to a nuget token variable name within `nuget.config`.
 - This Authorization package only uses the `ITokenFactory` interface definition from `JWT`, not the actual implementation, so it won't get negatively affected by this bump.