### PR TITLE
Bump Middleware package's JWT dependency version to `1.87.0`.

### DIFF
--- a/Hackney.Core/Hackney.Core.Middleware/Hackney.Core.Middleware.csproj
+++ b/Hackney.Core/Hackney.Core.Middleware/Hackney.Core.Middleware.csproj
@@ -13,6 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.2.0" />
-    <PackageReference Include="Hackney.Core.JWT" Version="1.27.1-preview0024" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.87.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# What:
 - Bump the `Hackney.Core.Middleware` pacakge's `Hackney.Core.JWT` dependencies version from `1.27.1-preview0024` to `1.87.0`.

# Why:
 - To reduce the risk of runtime crash errors when encountering Cognito Token getting introduced in future changes.

# Notes:
 - the jump from `1.27.1-preview` to `1.87.0` is backwards compatible in this case as the only thing the TokenFactory is getting used for by the Middleware is for Logging user's email. Nothing about email field's interface has changed up to the latest version of `JWT` package. 