### PR TITLE
Reduce pipeline step repetition for easier future changes.

### DIFF
--- a/.github/workflows/Hackney.Core.Authorization.yml
+++ b/.github/workflows/Hackney.Core.Authorization.yml
@@ -2,85 +2,23 @@ name: Hackney.Core.Authorization-publish
 on:
   push:
     branches:
-    - release
-    - feature/**
+      - release
+      - feature/**
     paths:
       - "Hackney.Core/Hackney.Core.Authorization/**"
       - "Hackney.Core.Tests/Hackney.Core.Tests.Authorization/**"
       - ".github/workflows/Hackney.Core.Authorization.yml"
+
 jobs:
-  calculate-version:
-    name: Calculate Version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.7
-        with:
-          versionSpec: '5.x'
-      - name: Determine package version
-        id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.7
-        with:
-          useConfigFile: true
-      - name: Display package version
-        run: |
-          echo "Version: $GITVERSION_NUGETVERSIONV2"
-
-  check-code-formatting:
-    name: Check code formatting
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install dotnet format
-        run: |
-          cd Hackney.Core
-          dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
-      - name: Run formatter check
-        run: |
-          cd Hackney.Core
-          ./dotnet-format-local/dotnet-format --check Hackney.Core.Authorization
-
-  build-and-test:
-    name: Build & Test
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    outputs:
-      version: ${{ needs.calculate-version.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build
-        run: docker compose build hackney-core-authorization-test
-      - name: Run tests
-        run: docker compose run hackney-core-authorization-test
-
-  publish-authorization-package:
-    name: Publish Authorization Package
-    runs-on: ubuntu-latest
-    needs: 
-      - check-code-formatting
-      - build-and-test
-    env:
-      VERSION: ${{ needs.build-and-test.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build the Package
-        run: |
-          cd Hackney.Core
-          dotnet pack Hackney.Core.Authorization -p:PackageVersion=$VERSION --configuration Release
-      - name: Publish the Package
-        run: |
-          cd Hackney.Core/Hackney.Core.Authorization/bin/Release
-          dotnet nuget push Hackney.Core.Authorization.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}
+  call:
+    uses: ./.github/workflows/reusable-publish.yml
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      project_root: Hackney.Core
+      pack_project: Hackney.Core.Authorization
+      package_name: Hackney.Core.Authorization
+      publish_dir: Hackney.Core/Hackney.Core.Authorization/bin/Release
+      docker_service: hackney-core-authorization-test
+      format_root: Hackney.Core
+      skip_tests: false

--- a/.github/workflows/Hackney.Core.Authorization.yml
+++ b/.github/workflows/Hackney.Core.Authorization.yml
@@ -1,4 +1,8 @@
 name: Hackney.Core.Authorization-publish
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:

--- a/.github/workflows/Hackney.Core.DynamoDb.yml
+++ b/.github/workflows/Hackney.Core.DynamoDb.yml
@@ -2,83 +2,23 @@ name: Hackney.Core.DynamoDb-publish
 on:
   push:
     branches:
-    - release
-    - feature/**
+      - release
+      - feature/**
     paths:
       - "Hackney.Core/Hackney.Core.DynamoDb/**"
       - "Hackney.Core.Tests/Hackney.Core.Tests.DynamoDb/**"
       - ".github/workflows/Hackney.Core.DynamoDb.yml"
+
 jobs:
-  calculate-version:
-    name: Calculate Version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.7
-        with:
-          versionSpec: '5.x'
-      - name: Determine package version
-        id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.7
-        with:
-          useConfigFile: true
-      - name: Display package version
-        run: |
-          echo "Version: $GITVERSION_NUGETVERSIONV2"
-          
-  check-code-formatting:
-    name: Check code formatting
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install dotnet format
-        run: |
-          cd Hackney.Core
-          dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
-      - name: Run formatter check
-        run: |
-          cd Hackney.Core
-          ./dotnet-format-local/dotnet-format --check Hackney.Core.DynamoDb
-
-  build-and-test:
-    name: Build & Test
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    outputs:
-      version: ${{ needs.calculate-version.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build
-        run: docker compose build hackney-core-dynamodb-test
-      - name: Run tests
-        run: docker compose run hackney-core-dynamodb-test
-
-  publish-package:
-    name: Publish Package
-    runs-on: ubuntu-latest
-    needs: build-and-test
-    env:
-      VERSION: ${{ needs.build-and-test.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build the Package
-        run: |
-          cd Hackney.Core
-          dotnet pack Hackney.Core.DynamoDb -p:PackageVersion=$VERSION --configuration Release
-      - name: Publish the Package
-        run: |
-          cd Hackney.Core/Hackney.Core.DynamoDb/bin/Release
-          dotnet nuget push Hackney.Core.DynamoDb.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}
+  call:
+    uses: ./.github/workflows/reusable-publish.yml
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      project_root: Hackney.Core
+      pack_project: Hackney.Core.DynamoDb
+      package_name: Hackney.Core.DynamoDb
+      publish_dir: Hackney.Core/Hackney.Core.DynamoDb/bin/Release
+      docker_service: hackney-core-dynamodb-test
+      format_root: Hackney.Core
+      skip_tests: false

--- a/.github/workflows/Hackney.Core.DynamoDb.yml
+++ b/.github/workflows/Hackney.Core.DynamoDb.yml
@@ -1,4 +1,8 @@
 name: Hackney.Core.DynamoDb-publish
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:

--- a/.github/workflows/Hackney.Core.ElasticSearch.yml
+++ b/.github/workflows/Hackney.Core.ElasticSearch.yml
@@ -2,83 +2,23 @@ name: Hackney.Core.ElasticSearch-publish
 on:
   push:
     branches:
-    - release
-    - feature/**
+      - release
+      - feature/**
     paths:
       - "Hackney.Core/Hackney.Core.ElasticSearch/**"
       - "Hackney.Core.Tests/Hackney.Core.Tests.ElasticSearch/**"
       - ".github/workflows/Hackney.Core.ElasticSearch.yml"
+
 jobs:
-  calculate-version:
-    name: Calculate Version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.7
-        with:
-          versionSpec: '5.x'
-      - name: Determine package version
-        id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.7
-        with:
-          useConfigFile: true
-      - name: Display package version
-        run: |
-          echo "Version: $GITVERSION_NUGETVERSIONV2"
-          
-  check-code-formatting:
-    name: Check code formatting
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install dotnet format
-        run: |
-          cd Hackney.Core
-          dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
-      - name: Run formatter check
-        run: |
-          cd Hackney.Core
-          ./dotnet-format-local/dotnet-format --check Hackney.Core.ElasticSearch
-
-  build-and-test:
-    name: Build & Test
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    outputs:
-      version: ${{ needs.calculate-version.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build
-        run: docker compose build hackney-core-elasticsearch-test
-      - name: Run tests
-        run: docker compose run hackney-core-elasticsearch-test
-
-  publish-package:
-    name: Publish Package
-    runs-on: ubuntu-latest
-    needs: build-and-test
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-      VERSION: ${{ needs.build-and-test.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build the Package
-        run: |
-          cd Hackney.Core
-          dotnet pack Hackney.Core.ElasticSearch -p:PackageVersion=$VERSION --configuration Release
-      - name: Publish the Package
-        run: |
-          cd Hackney.Core/Hackney.Core.ElasticSearch/bin/Release
-          dotnet nuget push Hackney.Core.ElasticSearch.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}
+  call:
+    uses: ./.github/workflows/reusable-publish.yml
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      project_root: Hackney.Core
+      pack_project: Hackney.Core.ElasticSearch
+      package_name: Hackney.Core.ElasticSearch
+      publish_dir: Hackney.Core/Hackney.Core.ElasticSearch/bin/Release
+      docker_service: hackney-core-elasticsearch-test
+      format_root: Hackney.Core
+      skip_tests: false

--- a/.github/workflows/Hackney.Core.ElasticSearch.yml
+++ b/.github/workflows/Hackney.Core.ElasticSearch.yml
@@ -1,4 +1,8 @@
 name: Hackney.Core.ElasticSearch-publish
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:

--- a/.github/workflows/Hackney.Core.Enums.yml
+++ b/.github/workflows/Hackney.Core.Enums.yml
@@ -2,83 +2,23 @@ name: Hackney.Core.Enums-publish
 on:
   push:
     branches:
-    - release
-    - feature/**
+      - release
+      - feature/**
     paths:
       - "Hackney.Core/Hackney.Core.Enums/**"
       - "Hackney.Core.Tests/Hackney.Core.Tests.Enums/**"
       - ".github/workflows/Hackney.Core.Enums.yml"
+
 jobs:
-  calculate-version:
-    name: Calculate Version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.7
-        with:
-          versionSpec: '5.x'
-      - name: Determine package version
-        id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.7
-        with:
-          useConfigFile: true
-      - name: Display package version
-        run: |
-          echo "Version: $GITVERSION_NUGETVERSIONV2"
-          
-  check-code-formatting:
-    name: Check code formatting
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install dotnet format
-        run: |
-          cd Hackney.Core
-          dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
-      - name: Run formatter check
-        run: |
-          cd Hackney.Core
-          ./dotnet-format-local/dotnet-format --check Hackney.Core.Enums
-
-  build-and-test:
-    name: Build & Test
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    outputs:
-      version: ${{ needs.calculate-version.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build
-        run: docker compose build hackney-core-enums-test
-      - name: Run tests
-        run: docker compose run hackney-core-enums-test
-
-  publish-package:
-    name: Publish Package
-    runs-on: ubuntu-latest
-    needs: build-and-test
-    env:
-      VERSION: ${{ needs.build-and-test.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build the Package
-        run: |
-          cd Hackney.Core
-          dotnet pack Hackney.Core.Enums -p:PackageVersion=$VERSION --configuration Release
-      - name: Publish the Package
-        run: |
-          cd Hackney.Core/Hackney.Core.Enums/bin/Release
-          dotnet nuget push Hackney.Core.Enums.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}
+  call:
+    uses: ./.github/workflows/reusable-publish.yml
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      project_root: Hackney.Core
+      pack_project: Hackney.Core.Enums
+      package_name: Hackney.Core.Enums
+      publish_dir: Hackney.Core/Hackney.Core.Enums/bin/Release
+      docker_service: hackney-core-enums-test
+      format_root: Hackney.Core
+      skip_tests: false

--- a/.github/workflows/Hackney.Core.Enums.yml
+++ b/.github/workflows/Hackney.Core.Enums.yml
@@ -1,4 +1,8 @@
 name: Hackney.Core.Enums-publish
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:

--- a/.github/workflows/Hackney.Core.HealthCheck.yml
+++ b/.github/workflows/Hackney.Core.HealthCheck.yml
@@ -1,4 +1,8 @@
 name: Hackney.Core.HealthCheck-publish
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:

--- a/.github/workflows/Hackney.Core.HealthCheck.yml
+++ b/.github/workflows/Hackney.Core.HealthCheck.yml
@@ -2,83 +2,23 @@ name: Hackney.Core.HealthCheck-publish
 on:
   push:
     branches:
-    - release
-    - feature/**
+      - release
+      - feature/**
     paths:
       - "Hackney.Core/Hackney.Core.HealthCheck/**"
       - "Hackney.Core.Tests/Hackney.Core.Tests.HealthCheck/**"
       - ".github/workflows/Hackney.Core.HealthCheck.yml"
+
 jobs:
-  calculate-version:
-    name: Calculate Version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.7
-        with:
-          versionSpec: '5.x'
-      - name: Determine package version
-        id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.7
-        with:
-          useConfigFile: true
-      - name: Display package version
-        run: |
-          echo "Version: $GITVERSION_NUGETVERSIONV2"
-          
-  check-code-formatting:
-    name: Check code formatting
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install dotnet format
-        run: |
-          cd Hackney.Core
-          dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
-      - name: Run formatter check
-        run: |
-          cd Hackney.Core
-          ./dotnet-format-local/dotnet-format --check Hackney.Core.HealthCheck
-
-  build-and-test:
-    name: Build & Test
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    outputs:
-      version: ${{ needs.calculate-version.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build
-        run: docker compose build hackney-core-healthcheck-test
-      - name: Run tests
-        run: docker compose run hackney-core-healthcheck-test
-
-  publish-package:
-    name: Publish Package
-    runs-on: ubuntu-latest
-    needs: build-and-test
-    env:
-      VERSION: ${{ needs.build-and-test.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build the Package
-        run: |
-          cd Hackney.Core
-          dotnet pack Hackney.Core.HealthCheck -p:PackageVersion=$VERSION --configuration Release
-      - name: Publish the Package
-        run: |
-          cd Hackney.Core/Hackney.Core.HealthCheck/bin/Release
-          dotnet nuget push Hackney.Core.HealthCheck.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}
+  call:
+    uses: ./.github/workflows/reusable-publish.yml
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      project_root: Hackney.Core
+      pack_project: Hackney.Core.HealthCheck
+      package_name: Hackney.Core.HealthCheck
+      publish_dir: Hackney.Core/Hackney.Core.HealthCheck/bin/Release
+      docker_service: hackney-core-healthcheck-test
+      format_root: Hackney.Core
+      skip_tests: false

--- a/.github/workflows/Hackney.Core.Http.yml
+++ b/.github/workflows/Hackney.Core.Http.yml
@@ -1,4 +1,8 @@
 name: Hackney.Core.Http-publish
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:

--- a/.github/workflows/Hackney.Core.Http.yml
+++ b/.github/workflows/Hackney.Core.Http.yml
@@ -2,83 +2,23 @@ name: Hackney.Core.Http-publish
 on:
   push:
     branches:
-    - release
-    - feature/**
+      - release
+      - feature/**
     paths:
       - "Hackney.Core/Hackney.Core.Http/**"
       - "Hackney.Core.Tests/Hackney.Core.Tests.Http/**"
       - ".github/workflows/Hackney.Core.Http.yml"
+
 jobs:
-  calculate-version:
-    name: Calculate Version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.7
-        with:
-          versionSpec: '5.x'
-      - name: Determine package version
-        id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.7
-        with:
-          useConfigFile: true
-      - name: Display package version
-        run: |
-          echo "Version: $GITVERSION_NUGETVERSIONV2"
-          
-  check-code-formatting:
-    name: Check code formatting
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install dotnet format
-        run: |
-          cd Hackney.Core
-          dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
-      - name: Run formatter check
-        run: |
-          cd Hackney.Core
-          ./dotnet-format-local/dotnet-format --check Hackney.Core.Http
-
-  build-and-test:
-    name: Build & Test
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    outputs:
-      version: ${{ needs.calculate-version.outputs.version }}
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build
-        run: docker compose build hackney-core-http-test
-      - name: Run tests
-        run: docker compose run hackney-core-http-test
-
-  publish-package:
-    name: Publish Package
-    runs-on: ubuntu-latest
-    needs: build-and-test
-    env:
-      VERSION: ${{ needs.build-and-test.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build the Package
-        run: |
-          cd Hackney.Core
-          dotnet pack Hackney.Core.Http -p:PackageVersion=$VERSION --configuration Release
-      - name: Publish the Package
-        run: |
-          cd Hackney.Core/Hackney.Core.Http/bin/Release
-          dotnet nuget push Hackney.Core.Http.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}
+  call:
+    uses: ./.github/workflows/reusable-publish.yml
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      project_root: Hackney.Core
+      pack_project: Hackney.Core.Http
+      package_name: Hackney.Core.Http
+      publish_dir: Hackney.Core/Hackney.Core.Http/bin/Release
+      docker_service: hackney-core-http-test
+      format_root: Hackney.Core
+      skip_tests: false

--- a/.github/workflows/Hackney.Core.JWT.yml
+++ b/.github/workflows/Hackney.Core.JWT.yml
@@ -2,83 +2,23 @@ name: Hackney.Core.JWT-publish
 on:
   push:
     branches:
-    - release
-    - feature/**
+      - release
+      - feature/**
     paths:
       - "Hackney.Core/Hackney.Core.JWT/**"
       - "Hackney.Core.Tests/Hackney.Core.Tests.JWT/**"
       - ".github/workflows/Hackney.Core.JWT.yml"
+
 jobs:
-  calculate-version:
-    name: Calculate Version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.7
-        with:
-          versionSpec: '5.x'
-      - name: Determine package version
-        id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.7
-        with:
-          useConfigFile: true
-      - name: Display package version
-        run: |
-          echo "Version: $GITVERSION_NUGETVERSIONV2"
-          
-  check-code-formatting:
-    name: Check code formatting
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install dotnet format
-        run: |
-          cd Hackney.Core
-          dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
-      - name: Run formatter check
-        run: |
-          cd Hackney.Core
-          ./dotnet-format-local/dotnet-format --check Hackney.Core.JWT
-
-  build-and-test:
-    name: Build & Test
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    outputs:
-      version: ${{ needs.calculate-version.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build
-        run: docker compose build hackney-core-jwt-test
-      - name: Run tests
-        run: docker compose run hackney-core-jwt-test
-
-  publish-package:
-    name: Publish Package
-    runs-on: ubuntu-latest
-    needs: build-and-test
-    env:
-      VERSION: ${{ needs.build-and-test.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build the Package
-        run: |
-          cd Hackney.Core
-          dotnet pack Hackney.Core.JWT -p:PackageVersion=$VERSION --configuration Release
-      - name: Publish the Package
-        run: |
-          cd Hackney.Core/Hackney.Core.JWT/bin/Release
-          dotnet nuget push Hackney.Core.JWT.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}
+  call:
+    uses: ./.github/workflows/reusable-publish.yml
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      project_root: Hackney.Core
+      pack_project: Hackney.Core.JWT
+      package_name: Hackney.Core.JWT
+      publish_dir: Hackney.Core/Hackney.Core.JWT/bin/Release
+      docker_service: hackney-core-jwt-test
+      format_root: Hackney.Core
+      skip_tests: false

--- a/.github/workflows/Hackney.Core.JWT.yml
+++ b/.github/workflows/Hackney.Core.JWT.yml
@@ -1,4 +1,8 @@
 name: Hackney.Core.JWT-publish
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:

--- a/.github/workflows/Hackney.Core.Logging.yml
+++ b/.github/workflows/Hackney.Core.Logging.yml
@@ -1,4 +1,8 @@
 name: Hackney.Core.Logging-publish
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:

--- a/.github/workflows/Hackney.Core.Logging.yml
+++ b/.github/workflows/Hackney.Core.Logging.yml
@@ -2,83 +2,23 @@ name: Hackney.Core.Logging-publish
 on:
   push:
     branches:
-    - release
-    - feature/**
+      - release
+      - feature/**
     paths:
       - "Hackney.Core/Hackney.Core.Logging/**"
       - "Hackney.Core.Tests/Hackney.Core.Tests.Logging/**"
       - ".github/workflows/Hackney.Core.Logging.yml"
+
 jobs:
-  calculate-version:
-    name: Calculate Version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.7
-        with:
-          versionSpec: '5.x'
-      - name: Determine package version
-        id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.7
-        with:
-          useConfigFile: true
-      - name: Display package version
-        run: |
-          echo "Version: $GITVERSION_NUGETVERSIONV2"
-          
-  check-code-formatting:
-    name: Check code formatting
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install dotnet format
-        run: |
-          cd Hackney.Core
-          dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
-      - name: Run formatter check
-        run: |
-          cd Hackney.Core
-          ./dotnet-format-local/dotnet-format --check Hackney.Core.Logging
-
-  build-and-test:
-    name: Build & Test
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    outputs:
-      version: ${{ needs.calculate-version.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build
-        run: docker compose build hackney-core-logging-test
-      - name: Run tests
-        run: docker compose run hackney-core-logging-test
-
-  publish-package:
-    name: Publish Package
-    runs-on: ubuntu-latest
-    needs: build-and-test
-    env:
-      VERSION: ${{ needs.build-and-test.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build the Package
-        run: |
-          cd Hackney.Core
-          dotnet pack Hackney.Core.Logging -p:PackageVersion=$VERSION --configuration Release
-      - name: Publish the Package
-        run: |
-          cd Hackney.Core/Hackney.Core.Logging/bin/Release
-          dotnet nuget push Hackney.Core.Logging.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}
+  call:
+    uses: ./.github/workflows/reusable-publish.yml
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      project_root: Hackney.Core
+      pack_project: Hackney.Core.Logging
+      package_name: Hackney.Core.Logging
+      publish_dir: Hackney.Core/Hackney.Core.Logging/bin/Release
+      docker_service: hackney-core-logging-test
+      format_root: Hackney.Core
+      skip_tests: false

--- a/.github/workflows/Hackney.Core.Middleware.yml
+++ b/.github/workflows/Hackney.Core.Middleware.yml
@@ -1,4 +1,8 @@
 name: Hackney.Core.Middleware-publish
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:

--- a/.github/workflows/Hackney.Core.Middleware.yml
+++ b/.github/workflows/Hackney.Core.Middleware.yml
@@ -2,83 +2,23 @@ name: Hackney.Core.Middleware-publish
 on:
   push:
     branches:
-    - release
-    - feature/**
+      - release
+      - feature/**
     paths:
       - "Hackney.Core/Hackney.Core.Middleware/**"
       - "Hackney.Core.Tests/Hackney.Core.Tests.Middleware/**"
       - ".github/workflows/Hackney.Core.Middleware.yml"
+
 jobs:
-  calculate-version:
-    name: Calculate Version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.7
-        with:
-          versionSpec: '5.x'
-      - name: Determine package version
-        id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.7
-        with:
-          useConfigFile: true
-      - name: Display package version
-        run: |
-          echo "Version: $GITVERSION_NUGETVERSIONV2"
-          
-  check-code-formatting:
-    name: Check code formatting
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install dotnet format
-        run: |
-          cd Hackney.Core
-          dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
-      - name: Run formatter check
-        run: |
-          cd Hackney.Core
-          ./dotnet-format-local/dotnet-format --check Hackney.Core.Middleware
-
-  build-and-test:
-    name: Build & Test
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    outputs:
-      version: ${{ needs.calculate-version.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build
-        run: docker compose build hackney-core-middleware-test
-      - name: Run tests
-        run: docker compose run hackney-core-middleware-test
-
-  publish-package:
-    name: Publish Package
-    runs-on: ubuntu-latest
-    needs: build-and-test
-    env:
-      VERSION: ${{ needs.build-and-test.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build the Package
-        run: |
-          cd Hackney.Core
-          dotnet pack Hackney.Core.Middleware -p:PackageVersion=$VERSION --configuration Release
-      - name: Publish the Package
-        run: |
-          cd Hackney.Core/Hackney.Core.Middleware/bin/Release
-          dotnet nuget push Hackney.Core.Middleware.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}
+  call:
+    uses: ./.github/workflows/reusable-publish.yml
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      project_root: Hackney.Core
+      pack_project: Hackney.Core.Middleware
+      package_name: Hackney.Core.Middleware
+      publish_dir: Hackney.Core/Hackney.Core.Middleware/bin/Release
+      docker_service: hackney-core-middleware-test
+      format_root: Hackney.Core
+      skip_tests: false

--- a/.github/workflows/Hackney.Core.Sns.yml
+++ b/.github/workflows/Hackney.Core.Sns.yml
@@ -2,83 +2,23 @@ name: Hackney.Core.Sns-publish
 on:
   push:
     branches:
-    - release
-    - feature/**
+      - release
+      - feature/**
     paths:
       - "Hackney.Core/Hackney.Core.Sns/**"
       - "Hackney.Core.Tests/Hackney.Core.Tests.Sns/**"
       - ".github/workflows/Hackney.Core.Sns.yml"
+
 jobs:
-  calculate-version:
-    name: Calculate Version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.7
-        with:
-          versionSpec: '5.x'
-      - name: Determine package version
-        id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.7
-        with:
-          useConfigFile: true
-      - name: Display package version
-        run: |
-          echo "Version: $GITVERSION_NUGETVERSIONV2"
-          
-  check-code-formatting:
-    name: Check code formatting
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install dotnet format
-        run: |
-          cd Hackney.Core
-          dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
-      - name: Run formatter check
-        run: |
-          cd Hackney.Core
-          ./dotnet-format-local/dotnet-format --check Hackney.Core.Sns
-
-  build-and-test:
-    name: Build & Test
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    outputs:
-      version: ${{ needs.calculate-version.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build
-        run: docker compose build hackney-core-sns-test
-      - name: Run tests
-        run: docker compose run hackney-core-sns-test
-
-  publish-package:
-    name: Publish Package
-    runs-on: ubuntu-latest
-    needs: build-and-test
-    env:
-      VERSION: ${{ needs.build-and-test.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build the Package
-        run: |
-          cd Hackney.Core
-          dotnet pack Hackney.Core.Sns -p:PackageVersion=$VERSION --configuration Release
-      - name: Publish the Package
-        run: |
-          cd Hackney.Core/Hackney.Core.Sns/bin/Release
-          dotnet nuget push Hackney.Core.Sns.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}
+  call:
+    uses: ./.github/workflows/reusable-publish.yml
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      project_root: Hackney.Core
+      pack_project: Hackney.Core.Sns
+      package_name: Hackney.Core.Sns
+      publish_dir: Hackney.Core/Hackney.Core.Sns/bin/Release
+      docker_service: hackney-core-sns-test
+      format_root: Hackney.Core
+      skip_tests: false

--- a/.github/workflows/Hackney.Core.Sns.yml
+++ b/.github/workflows/Hackney.Core.Sns.yml
@@ -1,4 +1,8 @@
 name: Hackney.Core.Sns-publish
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:

--- a/.github/workflows/Hackney.Core.Testing.DynamoDb.yml
+++ b/.github/workflows/Hackney.Core.Testing.DynamoDb.yml
@@ -2,66 +2,22 @@ name: Hackney.Core.Testing.DynamoDb-publish
 on:
   push:
     branches:
-    - release
-    - feature/**
+      - release
+      - feature/**
     paths:
       - "Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.DynamoDb/**"
       - ".github/workflows/Hackney.Core.Testing.DynamoDb.yml"
+
 jobs:
-  calculate-version:
-    name: Calculate Version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.7
-        with:
-          versionSpec: '5.x'
-      - name: Determine package version
-        id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.7
-        with:
-          useConfigFile: true
-      - name: Display package version
-        run: |
-          echo "Version: $GITVERSION_NUGETVERSIONV2"
-
-  check-code-formatting:
-    name: Check code formatting
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install dotnet format
-        run: |
-          cd Hackney.Core/Hackney.Core.Testing
-          dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
-      - name: Run formatter check
-        run: |
-          cd Hackney.Core/Hackney.Core.Testing
-          ./dotnet-format-local/dotnet-format --check Hackney.Core.Testing.DynamoDb
-
-  publish-package:
-    name: Publish Package
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    env:
-      VERSION: ${{ needs.calculate-version.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build the Package
-        run: |
-          cd Hackney.Core/Hackney.Core.Testing
-          dotnet pack Hackney.Core.Testing.DynamoDb -p:PackageVersion=$VERSION --configuration Release
-      - name: Publish the Package
-        run: |
-          cd Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.DynamoDb/bin/Release
-          dotnet nuget push Hackney.Core.Testing.DynamoDb.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}
+  call:
+    uses: ./.github/workflows/reusable-publish.yml
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      project_root: Hackney.Core/Hackney.Core.Testing
+      pack_project: Hackney.Core.Testing.DynamoDb
+      package_name: Hackney.Core.Testing.DynamoDb
+      publish_dir: Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.DynamoDb/bin/Release
+      docker_service: ""
+      format_root: Hackney.Core/Hackney.Core.Testing
+      skip_tests: true

--- a/.github/workflows/Hackney.Core.Testing.DynamoDb.yml
+++ b/.github/workflows/Hackney.Core.Testing.DynamoDb.yml
@@ -1,4 +1,8 @@
 name: Hackney.Core.Testing.DynamoDb-publish
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:

--- a/.github/workflows/Hackney.Core.Testing.ElasticSearch.yml
+++ b/.github/workflows/Hackney.Core.Testing.ElasticSearch.yml
@@ -2,66 +2,22 @@ name: Hackney.Core.Testing.ElasticSearch-publish
 on:
   push:
     branches:
-    - release
-    - feature/**
+      - release
+      - feature/**
     paths:
       - "Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.ElasticSearch/**"
       - ".github/workflows/Hackney.Core.Testing.ElasticSearch.yml"
+
 jobs:
-  calculate-version:
-    name: Calculate Version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.7
-        with:
-          versionSpec: '5.x'
-      - name: Determine package version
-        id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.7
-        with:
-          useConfigFile: true
-      - name: Display package version
-        run: |
-          echo "Version: $GITVERSION_NUGETVERSIONV2"
-
-  check-code-formatting:
-    name: Check code formatting
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install dotnet format
-        run: |
-          cd Hackney.Core/Hackney.Core.Testing
-          dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
-      - name: Run formatter check
-        run: |
-          cd Hackney.Core/Hackney.Core.Testing
-          ./dotnet-format-local/dotnet-format --check Hackney.Core.Testing.ElasticSearch
-
-  publish-package:
-    name: Publish Package
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    env:
-      VERSION: ${{ needs.calculate-version.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build the Package
-        run: |
-          cd Hackney.Core/Hackney.Core.Testing
-          dotnet pack Hackney.Core.Testing.ElasticSearch -p:PackageVersion=$VERSION --configuration Release
-      - name: Publish the Package
-        run: |
-          cd Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.ElasticSearch/bin/Release
-          dotnet nuget push Hackney.Core.Testing.ElasticSearch.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}
+  call:
+    uses: ./.github/workflows/reusable-publish.yml
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      project_root: Hackney.Core/Hackney.Core.Testing
+      pack_project: Hackney.Core.Testing.ElasticSearch
+      package_name: Hackney.Core.Testing.ElasticSearch
+      publish_dir: Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.ElasticSearch/bin/Release
+      docker_service: ""
+      format_root: Hackney.Core/Hackney.Core.Testing
+      skip_tests: true

--- a/.github/workflows/Hackney.Core.Testing.ElasticSearch.yml
+++ b/.github/workflows/Hackney.Core.Testing.ElasticSearch.yml
@@ -1,4 +1,8 @@
 name: Hackney.Core.Testing.ElasticSearch-publish
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:

--- a/.github/workflows/Hackney.Core.Testing.PactBroker.yml
+++ b/.github/workflows/Hackney.Core.Testing.PactBroker.yml
@@ -2,66 +2,22 @@ name: Hackney.Core.Testing.PactBroker-publish
 on:
   push:
     branches:
-    - release
-    - feature/**
+      - release
+      - feature/**
     paths:
       - "Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.PactBroker/**"
       - ".github/workflows/Hackney.Core.Testing.PactBroker.yml"
+
 jobs:
-  calculate-version:
-    name: Calculate Version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.7
-        with:
-          versionSpec: '5.x'
-      - name: Determine package version
-        id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.7
-        with:
-          useConfigFile: true
-      - name: Display package version
-        run: |
-          echo "Version: $GITVERSION_NUGETVERSIONV2"
-
-  check-code-formatting:
-    name: Check code formatting
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install dotnet format
-        run: |
-          cd Hackney.Core/Hackney.Core.Testing
-          dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
-      - name: Run formatter check
-        run: |
-          cd Hackney.Core/Hackney.Core.Testing
-          ./dotnet-format-local/dotnet-format --check Hackney.Core.Testing.PactBroker
-
-  publish-package:
-    name: Publish Package
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    env:
-      VERSION: ${{ needs.calculate-version.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build the Package
-        run: |
-          cd Hackney.Core/Hackney.Core.Testing
-          dotnet pack Hackney.Core.Testing.PactBroker -p:PackageVersion=$VERSION --configuration Release
-      - name: Publish the Package
-        run: |
-          cd Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.PactBroker/bin/Release
-          dotnet nuget push Hackney.Core.Testing.PactBroker.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}
+  call:
+    uses: ./.github/workflows/reusable-publish.yml
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      project_root: Hackney.Core/Hackney.Core.Testing
+      pack_project: Hackney.Core.Testing.PactBroker
+      package_name: Hackney.Core.Testing.PactBroker
+      publish_dir: Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.PactBroker/bin/Release
+      docker_service: ""
+      format_root: Hackney.Core/Hackney.Core.Testing
+      skip_tests: true

--- a/.github/workflows/Hackney.Core.Testing.PactBroker.yml
+++ b/.github/workflows/Hackney.Core.Testing.PactBroker.yml
@@ -1,4 +1,8 @@
 name: Hackney.Core.Testing.PactBroker-publish
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:

--- a/.github/workflows/Hackney.Core.Testing.Shared.yml
+++ b/.github/workflows/Hackney.Core.Testing.Shared.yml
@@ -2,66 +2,22 @@ name: Hackney.Core.Testing.Shared-publish
 on:
   push:
     branches:
-    - release
-    - feature/**
+      - release
+      - feature/**
     paths:
       - "Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/**"
       - ".github/workflows/Hackney.Core.Testing.Shared.yml"
+
 jobs:
-  calculate-version:
-    name: Calculate Version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.7
-        with:
-          versionSpec: '5.x'
-      - name: Determine package version
-        id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.7
-        with:
-          useConfigFile: true
-      - name: Display package version
-        run: |
-          echo "Version: $GITVERSION_NUGETVERSIONV2"
-
-  check-code-formatting:
-    name: Check code formatting
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install dotnet format
-        run: |
-          cd Hackney.Core/Hackney.Core.Testing
-          dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
-      - name: Run formatter check
-        run: |
-          cd Hackney.Core/Hackney.Core.Testing
-          ./dotnet-format-local/dotnet-format --check Hackney.Core.Testing.Shared
-
-  publish-package:
-    name: Publish Package
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    env:
-      VERSION: ${{ needs.calculate-version.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build the Package
-        run: |
-          cd Hackney.Core/Hackney.Core.Testing
-          dotnet pack Hackney.Core.Testing.Shared -p:PackageVersion=$VERSION --configuration Release
-      - name: Publish the Package
-        run: |
-          cd Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/bin/Release
-          dotnet nuget push Hackney.Core.Testing.Shared.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}
+  call:
+    uses: ./.github/workflows/reusable-publish.yml
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      project_root: Hackney.Core/Hackney.Core.Testing
+      pack_project: Hackney.Core.Testing.Shared
+      package_name: Hackney.Core.Testing.Shared
+      publish_dir: Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Shared/bin/Release
+      docker_service: ""
+      format_root: Hackney.Core/Hackney.Core.Testing
+      skip_tests: true

--- a/.github/workflows/Hackney.Core.Testing.Shared.yml
+++ b/.github/workflows/Hackney.Core.Testing.Shared.yml
@@ -1,4 +1,8 @@
 name: Hackney.Core.Testing.Shared-publish
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:

--- a/.github/workflows/Hackney.Core.Testing.Sns.yml
+++ b/.github/workflows/Hackney.Core.Testing.Sns.yml
@@ -1,4 +1,8 @@
 name: Hackney.Core.Testing.Sns-publish
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:

--- a/.github/workflows/Hackney.Core.Testing.Sns.yml
+++ b/.github/workflows/Hackney.Core.Testing.Sns.yml
@@ -2,66 +2,22 @@ name: Hackney.Core.Testing.Sns-publish
 on:
   push:
     branches:
-    - release
-    - feature/**
+      - release
+      - feature/**
     paths:
       - "Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Sns/**"
       - ".github/workflows/Hackney.Core.Testing.Sns.yml"
+
 jobs:
-  calculate-version:
-    name: Calculate Version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.7
-        with:
-          versionSpec: '5.x'
-      - name: Determine package version
-        id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.7
-        with:
-          useConfigFile: true
-      - name: Display package version
-        run: |
-          echo "Version: $GITVERSION_NUGETVERSIONV2"
-
-  check-code-formatting:
-    name: Check code formatting
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install dotnet format
-        run: |
-          cd Hackney.Core/Hackney.Core.Testing
-          dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
-      - name: Run formatter check
-        run: |
-          cd Hackney.Core/Hackney.Core.Testing
-          ./dotnet-format-local/dotnet-format --check Hackney.Core.Testing.Sns
-
-  publish-package:
-    name: Publish Package
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    env:
-      VERSION: ${{ needs.calculate-version.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build the Package
-        run: |
-          cd Hackney.Core/Hackney.Core.Testing
-          dotnet pack Hackney.Core.Testing.Sns -p:PackageVersion=$VERSION --configuration Release
-      - name: Publish the Package
-        run: |
-          cd Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Sns/bin/Release
-          dotnet nuget push Hackney.Core.Testing.Sns.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}
+  call:
+    uses: ./.github/workflows/reusable-publish.yml
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      project_root: Hackney.Core/Hackney.Core.Testing
+      pack_project: Hackney.Core.Testing.Sns
+      package_name: Hackney.Core.Testing.Sns
+      publish_dir: Hackney.Core/Hackney.Core.Testing/Hackney.Core.Testing.Sns/bin/Release
+      docker_service: ""
+      format_root: Hackney.Core/Hackney.Core.Testing
+      skip_tests: true

--- a/.github/workflows/Hackney.Core.Validation.AspNet.yml
+++ b/.github/workflows/Hackney.Core.Validation.AspNet.yml
@@ -1,4 +1,8 @@
 name: Hackney.Core.Validation.AspNet-publish
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:

--- a/.github/workflows/Hackney.Core.Validation.AspNet.yml
+++ b/.github/workflows/Hackney.Core.Validation.AspNet.yml
@@ -2,83 +2,23 @@ name: Hackney.Core.Validation.AspNet-publish
 on:
   push:
     branches:
-    - release
-    - feature/**
+      - release
+      - feature/**
     paths:
       - "Hackney.Core/Hackney.Core.Validation.AspNet/**"
       - "Hackney.Core.Tests.Validation.AspNet/**"
       - ".github/workflows/Hackney.Core.Validation.AspNet.yml"
+
 jobs:
-  calculate-version:
-    name: Calculate Version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.7
-        with:
-          versionSpec: '5.x'
-      - name: Determine package version
-        id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.7
-        with:
-          useConfigFile: true
-      - name: Display package version
-        run: |
-          echo "Version: $GITVERSION_NUGETVERSIONV2"
-          
-  check-code-formatting:
-    name: Check code formatting
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install dotnet format
-        run: |
-          cd Hackney.Core
-          dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
-      - name: Run formatter check
-        run: |
-          cd Hackney.Core
-          ./dotnet-format-local/dotnet-format --check Hackney.Core.Validation.AspNet
-
-  build-and-test:
-    name: Build & Test
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    outputs:
-      version: ${{ needs.calculate-version.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build
-        run: docker compose build hackney-core-validation-aspnet-test
-      - name: Run tests
-        run: docker compose run hackney-core-validation-aspnet-test
-
-  publish-package:
-    name: Publish Package
-    runs-on: ubuntu-latest
-    needs: build-and-test
-    env:
-      VERSION: ${{ needs.build-and-test.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build the Package
-        run: |
-          cd Hackney.Core
-          dotnet pack Hackney.Core.Validation.AspNet -p:PackageVersion=$VERSION --configuration Release
-      - name: Publish the Package
-        run: |
-          cd Hackney.Core/Hackney.Core.Validation.AspNet/bin/Release
-          dotnet nuget push Hackney.Core.Validation.AspNet.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}
+  call:
+    uses: ./.github/workflows/reusable-publish.yml
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      project_root: Hackney.Core
+      pack_project: Hackney.Core.Validation.AspNet
+      package_name: Hackney.Core.Validation.AspNet
+      publish_dir: Hackney.Core/Hackney.Core.Validation.AspNet/bin/Release
+      docker_service: hackney-core-validation-aspnet-test
+      format_root: Hackney.Core
+      skip_tests: false

--- a/.github/workflows/Hackney.Core.Validation.yml
+++ b/.github/workflows/Hackney.Core.Validation.yml
@@ -2,83 +2,23 @@ name: Hackney.Core.Validation-publish
 on:
   push:
     branches:
-    - release
-    - feature/**
+      - release
+      - feature/**
     paths:
       - "Hackney.Core/Hackney.Core.Validation/**"
       - "Hackney.Core.Tests/Hackney.Core.Tests.Validation/**"
       - ".github/workflows/Hackney.Core.Validation.yml"
+
 jobs:
-  calculate-version:
-    name: Calculate Version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.7
-        with:
-          versionSpec: '5.x'
-      - name: Determine package version
-        id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.7
-        with:
-          useConfigFile: true
-      - name: Display package version
-        run: |
-          echo "Version: $GITVERSION_NUGETVERSIONV2"
-          
-  check-code-formatting:
-    name: Check code formatting
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install dotnet format
-        run: |
-          cd Hackney.Core
-          dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
-      - name: Run formatter check
-        run: |
-          cd Hackney.Core
-          ./dotnet-format-local/dotnet-format --check Hackney.Core.Validation
-
-  build-and-test:
-    name: Build & Test
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    env:
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    outputs:
-      version: ${{ needs.calculate-version.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build
-        run: docker compose build hackney-core-validation-test
-      - name: Run tests
-        run: docker compose run hackney-core-validation-test
-
-  publish-package:
-    name: Publish Package
-    runs-on: ubuntu-latest
-    needs: build-and-test
-    env:
-      VERSION: ${{ needs.build-and-test.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build the Package
-        run: |
-          cd Hackney.Core
-          dotnet pack Hackney.Core.Validation -p:PackageVersion=$VERSION --configuration Release
-      - name: Publish the Package
-        run: |
-          cd Hackney.Core/Hackney.Core.Validation/bin/Release
-          dotnet nuget push Hackney.Core.Validation.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}
+  call:
+    uses: ./.github/workflows/reusable-publish.yml
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      project_root: Hackney.Core
+      pack_project: Hackney.Core.Validation
+      package_name: Hackney.Core.Validation
+      publish_dir: Hackney.Core/Hackney.Core.Validation/bin/Release
+      docker_service: hackney-core-validation-test
+      format_root: Hackney.Core
+      skip_tests: false

--- a/.github/workflows/Hackney.Core.Validation.yml
+++ b/.github/workflows/Hackney.Core.Validation.yml
@@ -1,4 +1,8 @@
 name: Hackney.Core.Validation-publish
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:

--- a/.github/workflows/Hackney.Shared.Strings.yml
+++ b/.github/workflows/Hackney.Shared.Strings.yml
@@ -2,81 +2,23 @@ name: Hackney.Shared.Strings-publish
 on:
   push:
     branches:
-    - release
-    - feature/**
-    - AddedSolutionFile
+      - release
+      - feature/**
+      - AddedSolutionFile
     paths:
       - "Hackney.Shared/Hackney.Shared.Strings/**"
       - ".github/workflows/Hackney.Shared.Strings.yml"
+
 jobs:
-  calculate-version:
-    name: Calculate Version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.7
-        with:
-          versionSpec: '5.x'
-      - name: Determine package version
-        id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.7
-        with:
-          useConfigFile: true
-      - name: Display package version
-        run: |
-          echo "Version: $GITVERSION_NUGETVERSIONV2"
-          
-  check-code-formatting:
-    name: Check code formatting
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install dotnet format
-        run: |
-          cd Hackney.Shared
-          dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
-      - name: Run formatter check
-        run: |
-          cd Hackney.Shared
-          ./dotnet-format-local/dotnet-format --check Hackney.Shared.Strings
-
-  # build-and-test:
-    # name: Build & Test
-    # runs-on: ubuntu-latest
-    # needs: calculate-version
-    # env:
-      # LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    # outputs:
-      # version: ${{ needs.calculate-version.outputs.version }}
-    # steps:
-      # - name: Checkout
-        # uses: actions/checkout@v2
-      # - name: Build
-        # run: docker compose build hackney-shared-strings      
-
-  publish-package:
-    name: Publish Package
-    runs-on: ubuntu-latest
-    needs: calculate-version
-    env:
-      VERSION: ${{ needs.calculate-version.outputs.version }}
-      LBHPACKAGESTOKEN: ${{secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build the Package
-        run: |
-          cd Hackney.Shared
-          dotnet pack Hackney.Shared.Strings -p:PackageVersion=$VERSION --configuration Release
-      - name: Publish the Package
-        run: |
-          cd Hackney.Shared/Hackney.Shared.Strings/bin/Release
-          dotnet nuget push Hackney.Shared.Strings.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{secrets.GITHUB_TOKEN }}
+  call:
+    uses: ./.github/workflows/reusable-publish.yml
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      project_root: Hackney.Shared
+      pack_project: Hackney.Shared.Strings
+      package_name: Hackney.Shared.Strings
+      publish_dir: Hackney.Shared/Hackney.Shared.Strings/bin/Release
+      docker_service: ""
+      format_root: Hackney.Shared
+      skip_tests: true

--- a/.github/workflows/Hackney.Shared.Strings.yml
+++ b/.github/workflows/Hackney.Shared.Strings.yml
@@ -1,4 +1,8 @@
 name: Hackney.Shared.Strings-publish
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:

--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -1,0 +1,110 @@
+name: Reusable Publish
+on:
+  workflow_call:
+    inputs:
+      project_root:
+        required: true
+        type: string
+      pack_project:
+        required: true
+        type: string
+      package_name:
+        required: true
+        type: string
+      publish_dir:
+        required: true
+        type: string
+      docker_service:
+        required: false
+        type: string
+        default: ""
+      format_root:
+        required: false
+        type: string
+        default: "Hackney.Core"
+      skip_tests:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  calculate-version:
+    name: Calculate Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0.9.7
+        with:
+          versionSpec: "5.x"
+      - id: gitversion
+        name: Determine package version
+        uses: gittools/actions/gitversion/execute@v0.9.7
+        with:
+          useConfigFile: true
+      - name: Display package version
+        run: |
+          echo "Version: $GITVERSION_NUGETVERSIONV2"
+
+  check-code-formatting:
+    name: Check code formatting
+    runs-on: ubuntu-latest
+    needs: calculate-version
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dotnet format
+        run: |
+          cd ${{ inputs.format_root }}
+          dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
+      - name: Run formatter check
+        run: |
+          cd ${{ inputs.format_root }}
+          ./dotnet-format-local/dotnet-format --check ${{ inputs.pack_project }}
+
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    needs: calculate-version
+    outputs:
+      version: ${{ needs.calculate-version.outputs.version }}
+    env:
+      LBHPACKAGESTOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and/or Run Tests
+        run: |
+          if [ "${{ inputs.docker_service }}" = "" ] || [ "${{ inputs.skip_tests }}" = "true" ]; then
+            echo "Skipping build-and-test for ${{ inputs.pack_project }}"
+          else
+            docker compose build ${{ inputs.docker_service }}
+            docker compose run ${{ inputs.docker_service }}
+          fi
+
+  publish-package:
+    name: Publish Package
+    runs-on: ubuntu-latest
+    needs:
+      - calculate-version
+      - check-code-formatting
+      - build-and-test
+    env:
+      VERSION: ${{ needs.calculate-version.outputs.version }}
+      LBHPACKAGESTOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build the Package
+        run: |
+          cd ${{ inputs.project_root }}
+          dotnet pack ${{ inputs.pack_project }} -p:PackageVersion=$VERSION --configuration Release
+      - name: Publish the Package
+        run: |
+          cd ${{ inputs.publish_dir }}
+          dotnet nuget push ${{ inputs.package_name }}.*.nupkg -s https://nuget.pkg.github.com/LBHackney-IT/index.json --api-key ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# What:
 - Extract the individual Nuget package workflows' repeated steps to a shared config.

# Why:
 - The same steps were repeated multiple times. Package release flow was hard to reason until all workflows were looked at because you couldn't rule out that 1 of them may be drastically different.
 - Doing any sort of logic edits to the pipeline would require changing nearly 20 files.

# Notes:
 - This updated pipeline will behave nearly exactly the same as the previous one with one exception: workflows that skip tests. In the old version, workflows would skip tests by not containing the the `build-and-test` job to begin with, while in the updated version that block does get run, but the act of running the tests is skipped. So it's effectively an empty job. When it comes to effective end-result behaviour, nothing really changed.
 - **Edit:** There's another difference between workflows - it's permissions. CodeQL scanner warns that when permissions of how GITHUB_TOKEN is used aren't limited, it defaults to repository permissions, which in the case of this repo (pre 2023) do not follow least privilege very well - they're highly permissive. Regardless, the current permissions set (quite limiting) should do just enough for this pipeline to function _(contents: read - allows pulling down code, packages: write - allows publishing)_. See more in Quotes section.
 - The permissions apparently need to get set at the caller workflow level, so sticking that permissions block into shared workflow config would only work if it was called directly, not through another workflow. When indirectly called, the permissions may get overridden.
 - This PR is in preparation of another PR to hopefully fix broken versioning logic. I'm doing this refactor work separately to make it easier for reviewers to verify that all is backwards compatible.

# Quotes
CodeQL warning:
> Actions job or workflow does not limit the permissions of the GITHUB_TOKEN. Consider setting an explicit permissions block, using the following as a minimal starting point: {}

> If a GitHub Actions job or workflow has no explicit permissions set, then the repository permissions are used. Repositories created under organizations inherit the organization permissions. The organizations or repositories created before February 2023 have the default permissions set to read-write. Often these permissions do not adhere to the principle of least privilege and can be reduced to read-only, leaving the write permission only to a specific types as issues: write or pull-requests: write.

> Note that this query cannot check whether the organization or repository token settings are set to read-only. However, even if they are, it is recommended to define explicit permissions (contents: read and packages: read are equivalent to the read-only default) so that (a) the actual needs of the workflow are documented, and (b) the permissions will remain restricted if the default is subsequently changed, or the workflow is copied to a different repository or organization.

>Recommendation
Add the permissions key to the job or the root of workflow (in this case it is applied to all jobs in the workflow that do not have their own permissions key) and assign the least privileges required to complete the task.