### PR TITLE
Prevent Github's token secret from being explicitly passed from a caller workflow.

### DIFF
--- a/.github/workflows/Hackney.Core.Authorization.yml
+++ b/.github/workflows/Hackney.Core.Authorization.yml
@@ -16,8 +16,7 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     with:
       project_root: Hackney.Core
       pack_project: Hackney.Core.Authorization

--- a/.github/workflows/Hackney.Core.Authorization.yml
+++ b/.github/workflows/Hackney.Core.Authorization.yml
@@ -16,7 +16,6 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-
     with:
       project_root: Hackney.Core
       pack_project: Hackney.Core.Authorization

--- a/.github/workflows/Hackney.Core.DynamoDb.yml
+++ b/.github/workflows/Hackney.Core.DynamoDb.yml
@@ -16,7 +16,6 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-
     with:
       project_root: Hackney.Core
       pack_project: Hackney.Core.DynamoDb

--- a/.github/workflows/Hackney.Core.DynamoDb.yml
+++ b/.github/workflows/Hackney.Core.DynamoDb.yml
@@ -16,8 +16,7 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     with:
       project_root: Hackney.Core
       pack_project: Hackney.Core.DynamoDb

--- a/.github/workflows/Hackney.Core.ElasticSearch.yml
+++ b/.github/workflows/Hackney.Core.ElasticSearch.yml
@@ -16,7 +16,6 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-
     with:
       project_root: Hackney.Core
       pack_project: Hackney.Core.ElasticSearch

--- a/.github/workflows/Hackney.Core.ElasticSearch.yml
+++ b/.github/workflows/Hackney.Core.ElasticSearch.yml
@@ -16,8 +16,7 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     with:
       project_root: Hackney.Core
       pack_project: Hackney.Core.ElasticSearch

--- a/.github/workflows/Hackney.Core.Enums.yml
+++ b/.github/workflows/Hackney.Core.Enums.yml
@@ -16,7 +16,6 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-
     with:
       project_root: Hackney.Core
       pack_project: Hackney.Core.Enums

--- a/.github/workflows/Hackney.Core.Enums.yml
+++ b/.github/workflows/Hackney.Core.Enums.yml
@@ -16,8 +16,7 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     with:
       project_root: Hackney.Core
       pack_project: Hackney.Core.Enums

--- a/.github/workflows/Hackney.Core.HealthCheck.yml
+++ b/.github/workflows/Hackney.Core.HealthCheck.yml
@@ -16,7 +16,6 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-
     with:
       project_root: Hackney.Core
       pack_project: Hackney.Core.HealthCheck

--- a/.github/workflows/Hackney.Core.HealthCheck.yml
+++ b/.github/workflows/Hackney.Core.HealthCheck.yml
@@ -16,8 +16,7 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     with:
       project_root: Hackney.Core
       pack_project: Hackney.Core.HealthCheck

--- a/.github/workflows/Hackney.Core.Http.yml
+++ b/.github/workflows/Hackney.Core.Http.yml
@@ -16,7 +16,6 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-
     with:
       project_root: Hackney.Core
       pack_project: Hackney.Core.Http

--- a/.github/workflows/Hackney.Core.Http.yml
+++ b/.github/workflows/Hackney.Core.Http.yml
@@ -16,8 +16,7 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     with:
       project_root: Hackney.Core
       pack_project: Hackney.Core.Http

--- a/.github/workflows/Hackney.Core.JWT.yml
+++ b/.github/workflows/Hackney.Core.JWT.yml
@@ -16,7 +16,6 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-
     with:
       project_root: Hackney.Core
       pack_project: Hackney.Core.JWT

--- a/.github/workflows/Hackney.Core.JWT.yml
+++ b/.github/workflows/Hackney.Core.JWT.yml
@@ -16,8 +16,7 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     with:
       project_root: Hackney.Core
       pack_project: Hackney.Core.JWT

--- a/.github/workflows/Hackney.Core.Logging.yml
+++ b/.github/workflows/Hackney.Core.Logging.yml
@@ -16,8 +16,7 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     with:
       project_root: Hackney.Core
       pack_project: Hackney.Core.Logging

--- a/.github/workflows/Hackney.Core.Logging.yml
+++ b/.github/workflows/Hackney.Core.Logging.yml
@@ -16,7 +16,6 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-
     with:
       project_root: Hackney.Core
       pack_project: Hackney.Core.Logging

--- a/.github/workflows/Hackney.Core.Middleware.yml
+++ b/.github/workflows/Hackney.Core.Middleware.yml
@@ -16,7 +16,6 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-
     with:
       project_root: Hackney.Core
       pack_project: Hackney.Core.Middleware

--- a/.github/workflows/Hackney.Core.Middleware.yml
+++ b/.github/workflows/Hackney.Core.Middleware.yml
@@ -16,8 +16,7 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     with:
       project_root: Hackney.Core
       pack_project: Hackney.Core.Middleware

--- a/.github/workflows/Hackney.Core.Sns.yml
+++ b/.github/workflows/Hackney.Core.Sns.yml
@@ -16,7 +16,6 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-
     with:
       project_root: Hackney.Core
       pack_project: Hackney.Core.Sns

--- a/.github/workflows/Hackney.Core.Sns.yml
+++ b/.github/workflows/Hackney.Core.Sns.yml
@@ -16,8 +16,7 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     with:
       project_root: Hackney.Core
       pack_project: Hackney.Core.Sns

--- a/.github/workflows/Hackney.Core.Testing.DynamoDb.yml
+++ b/.github/workflows/Hackney.Core.Testing.DynamoDb.yml
@@ -15,8 +15,7 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     with:
       project_root: Hackney.Core/Hackney.Core.Testing
       pack_project: Hackney.Core.Testing.DynamoDb

--- a/.github/workflows/Hackney.Core.Testing.DynamoDb.yml
+++ b/.github/workflows/Hackney.Core.Testing.DynamoDb.yml
@@ -15,7 +15,6 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-
     with:
       project_root: Hackney.Core/Hackney.Core.Testing
       pack_project: Hackney.Core.Testing.DynamoDb

--- a/.github/workflows/Hackney.Core.Testing.ElasticSearch.yml
+++ b/.github/workflows/Hackney.Core.Testing.ElasticSearch.yml
@@ -15,8 +15,7 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     with:
       project_root: Hackney.Core/Hackney.Core.Testing
       pack_project: Hackney.Core.Testing.ElasticSearch

--- a/.github/workflows/Hackney.Core.Testing.ElasticSearch.yml
+++ b/.github/workflows/Hackney.Core.Testing.ElasticSearch.yml
@@ -15,7 +15,6 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-
     with:
       project_root: Hackney.Core/Hackney.Core.Testing
       pack_project: Hackney.Core.Testing.ElasticSearch

--- a/.github/workflows/Hackney.Core.Testing.PactBroker.yml
+++ b/.github/workflows/Hackney.Core.Testing.PactBroker.yml
@@ -15,8 +15,7 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     with:
       project_root: Hackney.Core/Hackney.Core.Testing
       pack_project: Hackney.Core.Testing.PactBroker

--- a/.github/workflows/Hackney.Core.Testing.PactBroker.yml
+++ b/.github/workflows/Hackney.Core.Testing.PactBroker.yml
@@ -15,7 +15,6 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-
     with:
       project_root: Hackney.Core/Hackney.Core.Testing
       pack_project: Hackney.Core.Testing.PactBroker

--- a/.github/workflows/Hackney.Core.Testing.Shared.yml
+++ b/.github/workflows/Hackney.Core.Testing.Shared.yml
@@ -15,7 +15,6 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-
     with:
       project_root: Hackney.Core/Hackney.Core.Testing
       pack_project: Hackney.Core.Testing.Shared

--- a/.github/workflows/Hackney.Core.Testing.Shared.yml
+++ b/.github/workflows/Hackney.Core.Testing.Shared.yml
@@ -15,8 +15,7 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     with:
       project_root: Hackney.Core/Hackney.Core.Testing
       pack_project: Hackney.Core.Testing.Shared

--- a/.github/workflows/Hackney.Core.Testing.Sns.yml
+++ b/.github/workflows/Hackney.Core.Testing.Sns.yml
@@ -15,8 +15,7 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     with:
       project_root: Hackney.Core/Hackney.Core.Testing
       pack_project: Hackney.Core.Testing.Sns

--- a/.github/workflows/Hackney.Core.Testing.Sns.yml
+++ b/.github/workflows/Hackney.Core.Testing.Sns.yml
@@ -15,7 +15,6 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-
     with:
       project_root: Hackney.Core/Hackney.Core.Testing
       pack_project: Hackney.Core.Testing.Sns

--- a/.github/workflows/Hackney.Core.Validation.AspNet.yml
+++ b/.github/workflows/Hackney.Core.Validation.AspNet.yml
@@ -16,8 +16,7 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     with:
       project_root: Hackney.Core
       pack_project: Hackney.Core.Validation.AspNet

--- a/.github/workflows/Hackney.Core.Validation.AspNet.yml
+++ b/.github/workflows/Hackney.Core.Validation.AspNet.yml
@@ -16,7 +16,6 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-
     with:
       project_root: Hackney.Core
       pack_project: Hackney.Core.Validation.AspNet

--- a/.github/workflows/Hackney.Core.Validation.yml
+++ b/.github/workflows/Hackney.Core.Validation.yml
@@ -16,8 +16,7 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     with:
       project_root: Hackney.Core
       pack_project: Hackney.Core.Validation

--- a/.github/workflows/Hackney.Core.Validation.yml
+++ b/.github/workflows/Hackney.Core.Validation.yml
@@ -16,7 +16,6 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-
     with:
       project_root: Hackney.Core
       pack_project: Hackney.Core.Validation

--- a/.github/workflows/Hackney.Shared.Strings.yml
+++ b/.github/workflows/Hackney.Shared.Strings.yml
@@ -16,7 +16,6 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-
     with:
       project_root: Hackney.Shared
       pack_project: Hackney.Shared.Strings

--- a/.github/workflows/Hackney.Shared.Strings.yml
+++ b/.github/workflows/Hackney.Shared.Strings.yml
@@ -16,8 +16,7 @@ on:
 jobs:
   call:
     uses: ./.github/workflows/reusable-publish.yml
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     with:
       project_root: Hackney.Shared
       pack_project: Hackney.Shared.Strings


### PR DESCRIPTION
# What:
 - Don't pass Github token from the caller workflow - it's not necessary.

# Why:
 - Turns out Github secrets don't need to be passed in by a caller to a target workflow - that workflow can pull them out by itself. So when you try passing it explicitly, Github Actions falls over because it's looking for secrets matching the provided name within your custom configured environment. Since it's a Github's secret, it doesn't exist in any of your environments _(not that environment itself exists on this repository)_ - hence the failure.

# Notes:
 - Even if you configured it, you couldn't use it as it's a reserved keyword. So you can't use that name on the execution target workflow.
 - This is an extension of PR #72 .